### PR TITLE
chore: migrate Docker builds from private registry to Docker Hub

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -31,14 +31,17 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "📦 Building version: $VERSION"
 
+      - name: Log into Docker Hub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
       - name: Build and push Docker image
         run: |
           docker buildx build --platform linux/amd64 \
             --build-arg NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }} \
             --build-arg NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }} \
             --build-arg NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }} \
-            -t ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:${{ steps.version.outputs.version }} \
-            -t ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:dev-latest \
+            -t drumsergio/lynxprompt:${{ steps.version.outputs.version }} \
+            -t drumsergio/lynxprompt:dev-latest \
             --push .
 
       - name: Trigger Portainer deployment
@@ -50,7 +53,7 @@ jobs:
           cd geiserback-deploy
           
           # Update image tag
-          sed -i 's|image: .*/lynxprompt:.*|image: ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:${{ steps.version.outputs.version }}|' lynxprompt-dev/docker-compose.yml
+          sed -i 's|image: drumsergio/lynxprompt:.*|image: drumsergio/lynxprompt:${{ steps.version.outputs.version }}|' lynxprompt-dev/docker-compose.yml
           
           # Commit and push
           git config user.email "github-actions@lynxprompt.com"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,15 +34,18 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "✅ Deploying version $VERSION"
 
+      - name: Log into Docker Hub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
       - name: Build and push Docker image
         run: |
           docker buildx build --platform linux/amd64 \
             --build-arg NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }} \
             --build-arg NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }} \
             --build-arg NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }} \
-            -t ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:${{ steps.version.outputs.version }} \
+            -t drumsergio/lynxprompt:${{ steps.version.outputs.version }} \
             --push .
-          echo "✅ Built and pushed ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:${{ steps.version.outputs.version }}"
+          echo "✅ Built and pushed drumsergio/lynxprompt:${{ steps.version.outputs.version }}"
 
       - name: Update watchtower docker-compose with new version
         run: |
@@ -53,7 +56,7 @@ jobs:
           cd watchtower-deploy
           
           # Update image tag in docker-compose
-          sed -i 's|image: ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:.*|image: ${{ secrets.DOCKER_REGISTRY }}/lynxprompt:${{ steps.version.outputs.version }}|' lynxprompt/docker-compose.yml
+          sed -i 's|image: drumsergio/lynxprompt:.*|image: drumsergio/lynxprompt:${{ steps.version.outputs.version }}|' lynxprompt/docker-compose.yml
           
           # Commit and push
           git config user.email "github-actions@lynxprompt.com"


### PR DESCRIPTION
## Summary
- Switch CI/CD from `geiserback.mango-alpha.ts.net:5000` to `drumsergio/lynxprompt` on Docker Hub
- Add Docker Hub login step to both production and development deploy workflows
- Remove `DOCKER_REGISTRY` secret dependency (hardcoded `drumsergio/lynxprompt` like Telegram-Archive)
- Update sed commands in gitea compose update steps to match new image path

## Prerequisites
- [x] `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets added to repo
- [x] Current production image (`1.4.40-f0cc206`) already pushed to Docker Hub
- [x] Current dev image (`dev-20260126-de467f5`) already pushed to Docker Hub
- [x] Gitea docker-compose files updated to reference Docker Hub images

## Test plan
- [ ] Merge this PR (triggers production deploy)
- [ ] Verify build pushes to Docker Hub successfully
- [ ] Verify Portainer pulls from Docker Hub and deploys
- [ ] Verify health check passes