### PR TITLE
chore: bump CLI version to 1.6.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lynxprompt",
-  "version": "1.4.13",
+  "version": "1.6.0",
   "description": "CLI for LynxPrompt - Generate AI IDE configuration files",
   "author": "LynxPrompt Contributors",
   "license": "GPL-3.0",


### PR DESCRIPTION
Aligns CLI version with app version (1.6.0).