### PR TITLE
docs: add SVG banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/images/banner.svg" alt="LynxPrompt banner" width="900"/>
+</p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/GeiserX/LynxPrompt/main/public/logo.png">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/GeiserX/LynxPrompt/main/public/logo.png">

--- a/docs/images/banner.svg
+++ b/docs/images/banner.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 200" width="900" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#0D1B2A"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.05"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="200" rx="12" fill="url(#bg)"/>
+
+  <!-- Subtle grid -->
+  <g stroke="#ffffff" stroke-opacity="0.04" stroke-width="1">
+    <line x1="0" y1="50" x2="900" y2="50"/>
+    <line x1="0" y1="100" x2="900" y2="100"/>
+    <line x1="0" y1="150" x2="900" y2="150"/>
+    <line x1="150" y1="0" x2="150" y2="200"/>
+    <line x1="300" y1="0" x2="300" y2="200"/>
+    <line x1="450" y1="0" x2="450" y2="200"/>
+    <line x1="600" y1="0" x2="600" y2="200"/>
+    <line x1="750" y1="0" x2="750" y2="200"/>
+  </g>
+
+  <!-- Config file icon with code brackets -->
+  <g transform="translate(80, 50)">
+    <!-- Document shape -->
+    <rect x="0" y="0" width="72" height="100" rx="6" fill="url(#glow)" stroke="#ffffff" stroke-width="2" opacity="0.9"/>
+    <!-- Folded corner -->
+    <path d="M52,0 L72,20 L52,20 Z" fill="rgba(255,255,255,0.15)" stroke="#ffffff" stroke-width="1.5" opacity="0.7"/>
+    <!-- Code lines -->
+    <text x="12" y="48" font-family="monospace" font-size="16" fill="#ffffff" opacity="0.7">&lt;/&gt;</text>
+    <!-- Config dots -->
+    <rect x="12" y="58" width="48" height="4" rx="2" fill="#ffffff" opacity="0.3"/>
+    <rect x="12" y="68" width="36" height="4" rx="2" fill="#ffffff" opacity="0.25"/>
+    <rect x="12" y="78" width="42" height="4" rx="2" fill="#ffffff" opacity="0.2"/>
+  </g>
+
+  <!-- Title -->
+  <text x="195" y="95" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="48" font-weight="700" fill="#ffffff" letter-spacing="-1">
+    LynxPrompt
+  </text>
+
+  <!-- Subtitle -->
+  <text x="197" y="130" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="16" fill="#ffffff" opacity="0.65" letter-spacing="0.3">
+    Self-hosted AI config management for teams and individuals
+  </text>
+
+  <!-- Decorative: blueprint cards on right -->
+  <g transform="translate(740, 40)" opacity="0.15">
+    <rect x="0" y="0" width="60" height="40" rx="4" fill="#ffffff"/>
+    <rect x="8" y="10" width="30" height="4" rx="2" fill="#6366F1"/>
+    <rect x="8" y="20" width="44" height="4" rx="2" fill="#6366F1" opacity="0.6"/>
+    <rect x="8" y="30" width="24" height="4" rx="2" fill="#6366F1" opacity="0.4"/>
+
+    <rect x="20" y="50" width="60" height="40" rx="4" fill="#ffffff" opacity="0.7"/>
+    <rect x="28" y="60" width="30" height="4" rx="2" fill="#6366F1" opacity="0.5"/>
+    <rect x="28" y="70" width="44" height="4" rx="2" fill="#6366F1" opacity="0.4"/>
+
+    <rect x="40" y="100" width="60" height="40" rx="4" fill="#ffffff" opacity="0.5"/>
+    <rect x="48" y="110" width="30" height="4" rx="2" fill="#6366F1" opacity="0.4"/>
+    <rect x="48" y="120" width="44" height="4" rx="2" fill="#6366F1" opacity="0.3"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Adds a themed SVG banner (indigo gradient, config file with code brackets, blueprint cards)
- Preserves existing logo below the banner

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>