### PR TITLE
security: harden auth, SSO, path handling, access control

### DIFF
--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -4,7 +4,7 @@ import prompts from "prompts";
 import { api, ApiRequestError, Blueprint } from "../api.js";
 import { isAuthenticated } from "../config.js";
 import { writeFile, mkdir, readFile } from "fs/promises";
-import { join, dirname } from "path";
+import { join, dirname, resolve, relative } from "path";
 import { existsSync } from "fs";
 import {
   trackBlueprint,
@@ -17,6 +17,19 @@ interface PullOptions {
   yes?: boolean;
   preview?: boolean;
   track?: boolean; // Track the blueprint for future syncs (default: true)
+}
+
+/**
+ * Resolve a path under a root directory, rejecting traversal attempts.
+ * Throws if the resolved path escapes the root.
+ */
+function safePath(root: string, untrusted: string): string {
+  const resolved = resolve(root, untrusted);
+  const rel = relative(root, resolved);
+  if (rel.startsWith("..") || resolve(root, rel) !== resolved) {
+    throw new Error(`Path traversal blocked: ${untrusted}`);
+  }
+  return resolved;
 }
 
 // Mapping of blueprint types to filenames
@@ -135,7 +148,14 @@ async function pullHierarchy(
     for (const bp of blueprints) {
       // Determine output path - use repository_path if available
       const filename = bp.repository_path || TYPE_TO_FILENAME[bp.type] || "ai-config.md";
-      const outputPath = join(options.output, filename);
+      let outputPath: string;
+      try {
+        outputPath = safePath(resolve(options.output), filename);
+      } catch {
+        console.log(chalk.red(`  ✗ Skipped (invalid path): ${filename}`));
+        skipped++;
+        continue;
+      }
 
       // Check if file exists
       if (existsSync(outputPath) && !options.yes) {
@@ -290,7 +310,13 @@ async function pullBlueprint(
 
     // Determine output filename - use repository_path if available for hierarchy blueprints
     const filename = blueprint.repository_path || TYPE_TO_FILENAME[blueprint.type] || "ai-config.md";
-    const outputPath = join(options.output, filename);
+    let outputPath: string;
+    try {
+      outputPath = safePath(resolve(options.output), filename);
+    } catch {
+      console.error(chalk.red(`✗ Invalid file path: ${filename}`));
+      process.exit(1);
+    }
 
     // Check if file exists and show diff preview
     let localContent: string | null = null;

--- a/cli/src/commands/pull.ts
+++ b/cli/src/commands/pull.ts
@@ -4,7 +4,7 @@ import prompts from "prompts";
 import { api, ApiRequestError, Blueprint } from "../api.js";
 import { isAuthenticated } from "../config.js";
 import { writeFile, mkdir, readFile } from "fs/promises";
-import { join, dirname, resolve, relative } from "path";
+import { dirname, resolve, relative } from "path";
 import { existsSync } from "fs";
 import {
   trackBlueprint,

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -57,7 +57,7 @@ export async function GET(request: NextRequest) {
   // Find team and SSO config
   const team = await prismaUsers.team.findUnique({
     where: { slug: teamSlug },
-    include: { ssoConfig: true },
+    select: { id: true, slug: true, maxSeats: true, ssoConfig: true },
   });
 
   if (!team?.ssoConfig || !team.ssoConfig.enabled || team.ssoConfig.provider !== "OIDC") {
@@ -165,6 +165,16 @@ export async function GET(request: NextRequest) {
   });
 
   if (!existingMembership) {
+    // Enforce seat limit before adding member
+    const currentMembers = await prismaUsers.teamMember.count({
+      where: { teamId: team.id },
+    });
+    if (currentMembers >= team.maxSeats) {
+      return NextResponse.redirect(
+        new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
+      );
+    }
+
     await prismaUsers.teamMember.create({
       data: {
         teamId: team.id,

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -194,9 +194,10 @@ export async function GET(request: NextRequest) {
           new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
         );
       }
-      // Prisma P2034 = serialization failure — retry
+      // P2034 = serialization failure, P2002 = unique constraint (concurrent insert)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((err as any)?.code === "P2034" && attempt < MAX_RETRIES - 1) {
+      const code = (err as any)?.code;
+      if ((code === "P2034" || code === "P2002") && attempt < MAX_RETRIES - 1) {
         continue;
       }
       throw err;

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -148,49 +148,66 @@ export async function GET(request: NextRequest) {
   }
 
   // Atomically find-or-create user and enforce seat limit in a serializable transaction
-  // to prevent concurrent SSO logins from exceeding maxSeats
-  let seatLimitReached = false;
-  let user: { id: string; email: string | null; name: string | null };
+  // to prevent concurrent SSO logins from exceeding maxSeats.
+  // Retry up to 3 times on serialization conflicts (Prisma P2034).
+  const MAX_RETRIES = 3;
+  let user: { id: string; email: string | null; name: string | null } | undefined;
 
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    user = await prismaUsers.$transaction(async (tx: any) => {
-      let u = await tx.user.findUnique({ where: { email } });
-      const existingMembership = u
-        ? await tx.teamMember.findUnique({
-            where: { teamId_userId: { teamId: team.id, userId: u.id } },
-          })
-        : null;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    let seatLimitReached = false;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      user = await prismaUsers.$transaction(async (tx: any) => {
+        let u = await tx.user.findUnique({ where: { email } });
+        const existingMembership = u
+          ? await tx.teamMember.findUnique({
+              where: { teamId_userId: { teamId: team.id, userId: u.id } },
+            })
+          : null;
 
-      if (!existingMembership) {
-        const currentMembers = await tx.teamMember.count({
-          where: { teamId: team.id },
-        });
-        if (currentMembers >= team.maxSeats) {
-          seatLimitReached = true;
-          throw new Error("SEAT_LIMIT_REACHED");
+        if (!existingMembership) {
+          const currentMembers = await tx.teamMember.count({
+            where: { teamId: team.id },
+          });
+          if (currentMembers >= team.maxSeats) {
+            seatLimitReached = true;
+            throw new Error("SEAT_LIMIT_REACHED");
+          }
         }
-      }
 
-      if (!u) {
-        u = await tx.user.create({ data: { email, name } });
-      }
+        if (!u) {
+          u = await tx.user.create({ data: { email, name } });
+        }
 
-      if (!existingMembership) {
-        await tx.teamMember.create({
-          data: { teamId: team.id, userId: u.id, role: "MEMBER" },
-        });
-      }
+        if (!existingMembership) {
+          await tx.teamMember.create({
+            data: { teamId: team.id, userId: u.id, role: "MEMBER" },
+          });
+        }
 
-      return u;
-    }, { isolationLevel: "Serializable" });
-  } catch (err) {
-    if (seatLimitReached) {
-      return NextResponse.redirect(
-        new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
-      );
+        return u;
+      }, { isolationLevel: "Serializable" });
+      break; // Success — exit retry loop
+    } catch (err) {
+      if (seatLimitReached) {
+        return NextResponse.redirect(
+          new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
+        );
+      }
+      // Prisma P2034 = serialization failure — retry
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((err as any)?.code === "P2034" && attempt < MAX_RETRIES - 1) {
+        continue;
+      }
+      throw err;
     }
-    throw err;
+  }
+
+  // If we get here without user, all retries failed with serialization conflicts
+  if (!user) {
+    return NextResponse.redirect(
+      new URL("/auth/signin?error=SSOTemporaryError", request.url)
+    );
   }
 
   // Update last SSO sync

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac } from "crypto";
+import { createHmac, randomUUID } from "crypto";
 import { prismaUsers } from "@/lib/db-users";
 import { ENABLE_SSO } from "@/lib/feature-flags";
 import { decryptSSOConfig } from "@/lib/sso-encryption";
@@ -194,15 +194,28 @@ export async function GET(request: NextRequest) {
     data: { lastSyncAt: new Date() },
   });
 
+  // Generate a one-time nonce for the SSO completion handoff
+  const nonce = randomUUID();
+  const expires = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+
+  await prismaUsers.verificationToken.create({
+    data: {
+      identifier: `sso:${user.id}`,
+      token: nonce,
+      expires,
+    },
+  });
+
   // Redirect to the SSO sign-in completion page
   // This page triggers NextAuth signIn() with the SSO credentials
   const completeUrl = new URL("/auth/sso-complete", baseUrl);
   completeUrl.searchParams.set("userId", user.id);
   completeUrl.searchParams.set("email", email);
   completeUrl.searchParams.set("teamId", team.id);
+  completeUrl.searchParams.set("nonce", nonce);
   completeUrl.searchParams.set("callbackUrl", callbackUrl);
-  // Sign the params to prevent tampering
-  const signData = `${user.id}:${email}:${team.id}`;
+  // Sign all params including nonce to prevent tampering
+  const signData = `${user.id}:${email}:${team.id}:${nonce}`;
   const signature = createHmac("sha256", secret).update(signData).digest("hex");
   completeUrl.searchParams.set("sig", signature);
 

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -153,7 +153,8 @@ export async function GET(request: NextRequest) {
   let user: { id: string; email: string | null; name: string | null };
 
   try {
-    user = await prismaUsers.$transaction(async (tx: typeof prismaUsers) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    user = await prismaUsers.$transaction(async (tx: any) => {
       let u = await tx.user.findUnique({ where: { email } });
       const existingMembership = u
         ? await tx.teamMember.findUnique({

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -147,45 +147,49 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Check if user already exists and is already a team member
-  let user = await prismaUsers.user.findUnique({ where: { email } });
-  let existingMembership = user
-    ? await prismaUsers.teamMember.findUnique({
-        where: { teamId_userId: { teamId: team.id, userId: user.id } },
-      })
-    : null;
+  // Atomically find-or-create user and enforce seat limit in a serializable transaction
+  // to prevent concurrent SSO logins from exceeding maxSeats
+  let user: { id: string; email: string | null; name: string | null } | null = null;
+  let seatLimitReached = false;
 
-  // If user is not already a member, enforce seat limit BEFORE creating anything
-  if (!existingMembership) {
-    const currentMembers = await prismaUsers.teamMember.count({
-      where: { teamId: team.id },
-    });
-    if (currentMembers >= team.maxSeats) {
+  try {
+    user = await prismaUsers.$transaction(async (tx) => {
+      let u = await tx.user.findUnique({ where: { email } });
+      const existingMembership = u
+        ? await tx.teamMember.findUnique({
+            where: { teamId_userId: { teamId: team.id, userId: u.id } },
+          })
+        : null;
+
+      if (!existingMembership) {
+        const currentMembers = await tx.teamMember.count({
+          where: { teamId: team.id },
+        });
+        if (currentMembers >= team.maxSeats) {
+          seatLimitReached = true;
+          throw new Error("SEAT_LIMIT_REACHED");
+        }
+      }
+
+      if (!u) {
+        u = await tx.user.create({ data: { email, name } });
+      }
+
+      if (!existingMembership) {
+        await tx.teamMember.create({
+          data: { teamId: team.id, userId: u.id, role: "MEMBER" },
+        });
+      }
+
+      return u;
+    }, { isolationLevel: "Serializable" });
+  } catch (err) {
+    if (seatLimitReached) {
       return NextResponse.redirect(
         new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
       );
     }
-  }
-
-  // Safe to create user now — seat limit already verified
-  if (!user) {
-    user = await prismaUsers.user.create({
-      data: {
-        email,
-        name,
-      },
-    });
-  }
-
-  // Create membership if needed
-  if (!existingMembership) {
-    await prismaUsers.teamMember.create({
-      data: {
-        teamId: team.id,
-        userId: user.id,
-        role: "MEMBER",
-      },
-    });
+    throw err;
   }
 
   // Update last SSO sync

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -149,11 +149,11 @@ export async function GET(request: NextRequest) {
 
   // Atomically find-or-create user and enforce seat limit in a serializable transaction
   // to prevent concurrent SSO logins from exceeding maxSeats
-  let user: { id: string; email: string | null; name: string | null } | null = null;
   let seatLimitReached = false;
+  let user: { id: string; email: string | null; name: string | null };
 
   try {
-    user = await prismaUsers.$transaction(async (tx) => {
+    user = await prismaUsers.$transaction(async (tx: typeof prismaUsers) => {
       let u = await tx.user.findUnique({ where: { email } });
       const existingMembership = u
         ? await tx.teamMember.findUnique({

--- a/src/app/api/auth/sso/callback/oidc/route.ts
+++ b/src/app/api/auth/sso/callback/oidc/route.ts
@@ -147,9 +147,27 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Find or create user, then add to team
+  // Check if user already exists and is already a team member
   let user = await prismaUsers.user.findUnique({ where: { email } });
+  let existingMembership = user
+    ? await prismaUsers.teamMember.findUnique({
+        where: { teamId_userId: { teamId: team.id, userId: user.id } },
+      })
+    : null;
 
+  // If user is not already a member, enforce seat limit BEFORE creating anything
+  if (!existingMembership) {
+    const currentMembers = await prismaUsers.teamMember.count({
+      where: { teamId: team.id },
+    });
+    if (currentMembers >= team.maxSeats) {
+      return NextResponse.redirect(
+        new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
+      );
+    }
+  }
+
+  // Safe to create user now — seat limit already verified
   if (!user) {
     user = await prismaUsers.user.create({
       data: {
@@ -159,22 +177,8 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Ensure user is a member of the team
-  const existingMembership = await prismaUsers.teamMember.findUnique({
-    where: { teamId_userId: { teamId: team.id, userId: user.id } },
-  });
-
+  // Create membership if needed
   if (!existingMembership) {
-    // Enforce seat limit before adding member
-    const currentMembers = await prismaUsers.teamMember.count({
-      where: { teamId: team.id },
-    });
-    if (currentMembers >= team.maxSeats) {
-      return NextResponse.redirect(
-        new URL("/auth/signin?error=SSOSeatLimitReached", request.url)
-      );
-    }
-
     await prismaUsers.teamMember.create({
       data: {
         teamId: team.id,

--- a/src/app/api/billing/status/route.ts
+++ b/src/app/api/billing/status/route.ts
@@ -40,20 +40,22 @@ export async function GET() {
       );
     }
 
-    const teamMembership = user.teamMemberships[0];
     const isAdmin = user.role === "ADMIN" || user.role === "SUPERADMIN";
+    const teams = user.teamMemberships.map((m) => ({
+      id: m.team.id,
+      name: m.team.name,
+      slug: m.team.slug,
+      logo: m.team.logo,
+      role: m.role,
+    }));
 
     return NextResponse.json({
       plan: "free",
       isAdmin,
-      isTeamsUser: !!teamMembership,
-      team: teamMembership ? {
-        id: teamMembership.team.id,
-        name: teamMembership.team.name,
-        slug: teamMembership.team.slug,
-        logo: teamMembership.team.logo,
-        role: teamMembership.role,
-      } : null,
+      isTeamsUser: teams.length > 0,
+      // Keep backward-compat: "team" returns first membership
+      team: teams[0] ?? null,
+      teams,
     });
   } catch (error) {
     console.error("Error fetching subscription status:", error);

--- a/src/app/api/blueprints/[id]/download/route.ts
+++ b/src/app/api/blueprints/[id]/download/route.ts
@@ -30,9 +30,11 @@ export async function POST(
       }
     }
 
-    // Determine template type from ID prefix and strip bp_ for DB queries
+    // Determine template type from ID prefix and strip prefix for DB queries
     const templateType = rawId.startsWith("sys_") ? "system" : "user";
-    const dbId = rawId.startsWith("bp_") ? rawId.slice(3) : rawId;
+    const dbId = rawId.startsWith("bp_") ? rawId.slice(3)
+      : rawId.startsWith("sys_") ? rawId.slice(4)
+      : rawId;
 
     // Deduplicate: check for recent download from same IP + template in the last hour
     const clientIP = request.headers.get("cf-connecting-ip") ||
@@ -68,10 +70,10 @@ export async function POST(
       },
     });
 
-    // Increment downloads count on template — use dbId (without bp_ prefix)
+    // Increment downloads count on template — use dbId (without prefix)
     if (templateType === "system") {
       await prismaApp.systemTemplate.update({
-        where: { id: rawId },
+        where: { id: dbId },
         data: { downloads: { increment: 1 } },
       });
     } else {
@@ -96,7 +98,9 @@ export async function GET(
 ) {
   const { id: rawId } = await params;
   const templateType = rawId.startsWith("sys_") ? "system" : "user";
-  const dbId = rawId.startsWith("bp_") ? rawId.slice(3) : rawId;
+  const dbId = rawId.startsWith("bp_") ? rawId.slice(3)
+    : rawId.startsWith("sys_") ? rawId.slice(4)
+    : rawId;
 
   try {
     // For user blueprints, verify the requester owns it or it's public

--- a/src/app/api/blueprints/[id]/download/route.ts
+++ b/src/app/api/blueprints/[id]/download/route.ts
@@ -11,7 +11,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await getServerSession(authOptions);
-  const { id } = await params;
+  const { id: rawId } = await params;
 
   try {
     const body = await request.json().catch(() => ({}));
@@ -30,8 +30,9 @@ export async function POST(
       }
     }
 
-    // Determine template type from ID prefix
-    const templateType = id.startsWith("sys_") ? "system" : "user";
+    // Determine template type from ID prefix and strip bp_ for DB queries
+    const templateType = rawId.startsWith("sys_") ? "system" : "user";
+    const dbId = rawId.startsWith("bp_") ? rawId.slice(3) : rawId;
 
     // Deduplicate: check for recent download from same IP + template in the last hour
     const clientIP = request.headers.get("cf-connecting-ip") ||
@@ -43,7 +44,7 @@ export async function POST(
 
     const recentDownload = await prismaUsers.templateDownload.findFirst({
       where: {
-        templateId: id,
+        templateId: rawId,
         templateType,
         ipHash,
         createdAt: { gte: oneHourAgo },
@@ -60,22 +61,22 @@ export async function POST(
     await prismaUsers.templateDownload.create({
       data: {
         userId: session?.user?.id || null,
-        templateId: id,
+        templateId: rawId,
         templateType,
         platform,
         ipHash,
       },
     });
 
-    // Increment downloads count on template
+    // Increment downloads count on template — use dbId (without bp_ prefix)
     if (templateType === "system") {
       await prismaApp.systemTemplate.update({
-        where: { id },
+        where: { id: rawId },
         data: { downloads: { increment: 1 } },
       });
     } else {
       await prismaUsers.userTemplate.update({
-        where: { id },
+        where: { id: dbId },
         data: { downloads: { increment: 1 } },
       });
     }
@@ -93,14 +94,15 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params;
-  const templateType = id.startsWith("sys_") ? "system" : "user";
+  const { id: rawId } = await params;
+  const templateType = rawId.startsWith("sys_") ? "system" : "user";
+  const dbId = rawId.startsWith("bp_") ? rawId.slice(3) : rawId;
 
   try {
     // For user blueprints, verify the requester owns it or it's public
     if (templateType === "user") {
       const template = await prismaUsers.userTemplate.findUnique({
-        where: { id },
+        where: { id: dbId },
         select: { visibility: true, userId: true, teamId: true },
       });
       if (!template) {
@@ -125,10 +127,10 @@ export async function GET(
       }
     }
 
-    // Get total downloads
+    // Get total downloads — templateDownload stores the raw ID (with bp_ prefix)
     const downloadCount = await prismaUsers.templateDownload.count({
       where: {
-        templateId: id,
+        templateId: rawId,
         templateType,
       },
     });
@@ -137,7 +139,7 @@ export async function GET(
     const platformStats = await prismaUsers.templateDownload.groupBy({
       by: ["platform"],
       where: {
-        templateId: id,
+        templateId: rawId,
         templateType,
       },
       _count: true,

--- a/src/app/api/blueprints/[id]/download/route.ts
+++ b/src/app/api/blueprints/[id]/download/route.ts
@@ -97,6 +97,34 @@ export async function GET(
   const templateType = id.startsWith("sys_") ? "system" : "user";
 
   try {
+    // For user blueprints, verify the requester owns it or it's public
+    if (templateType === "user") {
+      const template = await prismaUsers.userTemplate.findUnique({
+        where: { id },
+        select: { visibility: true, userId: true, teamId: true },
+      });
+      if (!template) {
+        return NextResponse.json({ total: 0, byPlatform: {} });
+      }
+      if (template.visibility !== "PUBLIC") {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const isOwner = template.userId === session.user.id;
+        let isTeamMember = false;
+        if (template.teamId) {
+          const membership = await prismaUsers.teamMember.findUnique({
+            where: { teamId_userId: { teamId: template.teamId, userId: session.user.id } },
+          });
+          isTeamMember = !!membership;
+        }
+        if (!isOwner && !isTeamMember) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+      }
+    }
+
     // Get total downloads
     const downloadCount = await prismaUsers.templateDownload.count({
       where: {

--- a/src/app/api/blueprints/route.ts
+++ b/src/app/api/blueprints/route.ts
@@ -501,7 +501,7 @@ export async function POST(request: NextRequest) {
         // Hierarchy fields
         hierarchyId: hierarchyId?.trim() || null,
         parentId: validatedParentId,
-        repositoryPath: repositoryPath?.trim() || null,
+        repositoryPath: repositoryPath?.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, "") || null,
       },
     });
 

--- a/src/app/api/blueprints/route.ts
+++ b/src/app/api/blueprints/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { posix as posixPath } from "path";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prismaUsers } from "@/lib/db-users";
@@ -55,6 +56,13 @@ type BlueprintType = (typeof BLUEPRINT_TYPES)[number];
 /**
  * Determine tier based on total word count (all content including comments/headers).
  */
+function sanitizeRepositoryPath(input: string | null | undefined): string | null {
+  if (!input?.trim()) return null;
+  const normalized = posixPath.normalize(input.trim()).replace(/^[/\\]+/, "");
+  if (normalized.startsWith("..") || normalized.includes("/..")) return null;
+  return normalized || null;
+}
+
 function determineTier(content: string): "SHORT" | "INTERMEDIATE" | "LONG" | "SUPERLONG" {
   const wordCount = content.split(/\s+/).filter(Boolean).length;
   
@@ -501,7 +509,7 @@ export async function POST(request: NextRequest) {
         // Hierarchy fields
         hierarchyId: hierarchyId?.trim() || null,
         parentId: validatedParentId,
-        repositoryPath: repositoryPath?.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, "") || null,
+        repositoryPath: sanitizeRepositoryPath(repositoryPath) || null,
       },
     });
 

--- a/src/app/api/hierarchies/[id]/blueprints/route.ts
+++ b/src/app/api/hierarchies/[id]/blueprints/route.ts
@@ -128,7 +128,7 @@ export async function POST(
       where: { id: bpId },
       data: {
         hierarchyId,
-        repositoryPath: repositoryPath.trim(),
+        repositoryPath: repositoryPath.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, ""),
         parentId: parentBpId,
       },
       select: {

--- a/src/app/api/hierarchies/[id]/blueprints/route.ts
+++ b/src/app/api/hierarchies/[id]/blueprints/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { posix as posixPath } from "path";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prismaUsers } from "@/lib/db-users";
@@ -8,6 +9,13 @@ import { prismaUsers } from "@/lib/db-users";
  */
 function fromHierarchyId(id: string): string {
   return id.startsWith("ha_") ? id.slice(3) : id;
+}
+
+function sanitizeRepositoryPath(input: string | null | undefined): string | null {
+  if (!input?.trim()) return null;
+  const normalized = posixPath.normalize(input.trim()).replace(/^[/\\]+/, "");
+  if (normalized.startsWith("..") || normalized.includes("/..")) return null;
+  return normalized || null;
 }
 
 /**
@@ -128,7 +136,7 @@ export async function POST(
       where: { id: bpId },
       data: {
         hierarchyId,
-        repositoryPath: repositoryPath.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, ""),
+        repositoryPath: sanitizeRepositoryPath(repositoryPath) ?? "",
         parentId: parentBpId,
       },
       select: {

--- a/src/app/api/teams/invite/accept/route.ts
+++ b/src/app/api/teams/invite/accept/route.ts
@@ -104,7 +104,8 @@ export async function POST(request: NextRequest) {
     // Atomically check seats + create membership in a serializable transaction
     let seatLimitReached = false;
     try {
-      await prismaUsers.$transaction(async (tx: typeof prismaUsers) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await prismaUsers.$transaction(async (tx: any) => {
         const currentMembers = await tx.teamMember.count({
           where: { teamId: invitation.teamId },
         });

--- a/src/app/api/teams/invite/accept/route.ts
+++ b/src/app/api/teams/invite/accept/route.ts
@@ -101,44 +101,47 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check seat availability
-    const currentMembers = invitation.team._count.members;
-    if (currentMembers >= invitation.team.maxSeats) {
-      return NextResponse.json(
-        { error: "This team has reached its maximum seat limit. Contact the team admin." },
-        { status: 400 }
-      );
-    }
+    // Atomically check seats + create membership in a serializable transaction
+    let seatLimitReached = false;
+    try {
+      await prismaUsers.$transaction(async (tx: typeof prismaUsers) => {
+        const currentMembers = await tx.teamMember.count({
+          where: { teamId: invitation.teamId },
+        });
+        if (currentMembers >= invitation.team.maxSeats) {
+          seatLimitReached = true;
+          throw new Error("SEAT_LIMIT_REACHED");
+        }
 
-    // Accept the invitation: create membership and update invitation
-    await prismaUsers.$transaction([
-      // Create team membership
-      prismaUsers.teamMember.create({
-        data: {
-          teamId: invitation.teamId,
-          userId: session.user.id,
-          role: invitation.role,
-          isActiveThisCycle: true,
-          lastActiveAt: new Date(),
-        },
-      }),
-      // Mark invitation as accepted
-      prismaUsers.teamInvitation.update({
-        where: { id: invitation.id },
-        data: {
-          status: "ACCEPTED",
-          acceptedAt: new Date(),
-        },
-      }),
-      // Update user's subscription plan to TEAMS
-      prismaUsers.user.update({
-        where: { id: session.user.id },
-        data: {
-          subscriptionPlan: "TEAMS",
-          lastLoginAt: new Date(),
-        },
-      }),
-    ]);
+        await tx.teamMember.create({
+          data: {
+            teamId: invitation.teamId,
+            userId: session.user.id,
+            role: invitation.role,
+            isActiveThisCycle: true,
+            lastActiveAt: new Date(),
+          },
+        });
+
+        await tx.teamInvitation.update({
+          where: { id: invitation.id },
+          data: { status: "ACCEPTED", acceptedAt: new Date() },
+        });
+
+        await tx.user.update({
+          where: { id: session.user.id },
+          data: { subscriptionPlan: "TEAMS", lastLoginAt: new Date() },
+        });
+      }, { isolationLevel: "Serializable" });
+    } catch (err) {
+      if (seatLimitReached) {
+        return NextResponse.json(
+          { error: "This team has reached its maximum seat limit. Contact the team admin." },
+          { status: 400 }
+        );
+      }
+      throw err;
+    }
 
     return NextResponse.json({
       message: `Welcome to ${invitation.team.name}!`,

--- a/src/app/api/teams/invite/accept/route.ts
+++ b/src/app/api/teams/invite/accept/route.ts
@@ -101,47 +101,67 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Atomically check seats + create membership in a serializable transaction
-    let seatLimitReached = false;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await prismaUsers.$transaction(async (tx: any) => {
-        const currentMembers = await tx.teamMember.count({
-          where: { teamId: invitation.teamId },
-        });
-        if (currentMembers >= invitation.team.maxSeats) {
-          seatLimitReached = true;
-          throw new Error("SEAT_LIMIT_REACHED");
+    // Atomically check seats + create membership in a serializable transaction.
+    // Retry up to 3 times on serialization conflicts (Prisma P2034).
+    const MAX_RETRIES = 3;
+    let accepted = false;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      let seatLimitReached = false;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await prismaUsers.$transaction(async (tx: any) => {
+          const currentMembers = await tx.teamMember.count({
+            where: { teamId: invitation.teamId },
+          });
+          if (currentMembers >= invitation.team.maxSeats) {
+            seatLimitReached = true;
+            throw new Error("SEAT_LIMIT_REACHED");
+          }
+
+          await tx.teamMember.create({
+            data: {
+              teamId: invitation.teamId,
+              userId: session.user.id,
+              role: invitation.role,
+              isActiveThisCycle: true,
+              lastActiveAt: new Date(),
+            },
+          });
+
+          await tx.teamInvitation.update({
+            where: { id: invitation.id },
+            data: { status: "ACCEPTED", acceptedAt: new Date() },
+          });
+
+          await tx.user.update({
+            where: { id: session.user.id },
+            data: { subscriptionPlan: "TEAMS", lastLoginAt: new Date() },
+          });
+        }, { isolationLevel: "Serializable" });
+        accepted = true;
+        break; // Success — exit retry loop
+      } catch (err) {
+        if (seatLimitReached) {
+          return NextResponse.json(
+            { error: "This team has reached its maximum seat limit. Contact the team admin." },
+            { status: 400 }
+          );
         }
-
-        await tx.teamMember.create({
-          data: {
-            teamId: invitation.teamId,
-            userId: session.user.id,
-            role: invitation.role,
-            isActiveThisCycle: true,
-            lastActiveAt: new Date(),
-          },
-        });
-
-        await tx.teamInvitation.update({
-          where: { id: invitation.id },
-          data: { status: "ACCEPTED", acceptedAt: new Date() },
-        });
-
-        await tx.user.update({
-          where: { id: session.user.id },
-          data: { subscriptionPlan: "TEAMS", lastLoginAt: new Date() },
-        });
-      }, { isolationLevel: "Serializable" });
-    } catch (err) {
-      if (seatLimitReached) {
-        return NextResponse.json(
-          { error: "This team has reached its maximum seat limit. Contact the team admin." },
-          { status: 400 }
-        );
+        // Prisma P2034 = serialization failure — retry
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((err as any)?.code === "P2034" && attempt < MAX_RETRIES - 1) {
+          continue;
+        }
+        throw err;
       }
-      throw err;
+    }
+
+    if (!accepted) {
+      return NextResponse.json(
+        { error: "Failed to accept invitation due to a conflict. Please try again." },
+        { status: 409 }
+      );
     }
 
     return NextResponse.json({

--- a/src/app/api/teams/invite/accept/route.ts
+++ b/src/app/api/teams/invite/accept/route.ts
@@ -111,6 +111,15 @@ export async function POST(request: NextRequest) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await prismaUsers.$transaction(async (tx: any) => {
+          // Re-check membership inside transaction (handles parallel submissions)
+          const alreadyMember = await tx.teamMember.findUnique({
+            where: { teamId_userId: { teamId: invitation.teamId, userId: session.user.id } },
+          });
+          if (alreadyMember) {
+            accepted = true; // Treat as idempotent success
+            return;
+          }
+
           const currentMembers = await tx.teamMember.count({
             where: { teamId: invitation.teamId },
           });

--- a/src/app/api/teams/invite/accept/route.ts
+++ b/src/app/api/teams/invite/accept/route.ts
@@ -157,9 +157,10 @@ export async function POST(request: NextRequest) {
             { status: 400 }
           );
         }
-        // Prisma P2034 = serialization failure — retry
+        // P2034 = serialization failure, P2002 = unique constraint (concurrent insert)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if ((err as any)?.code === "P2034" && attempt < MAX_RETRIES - 1) {
+        const code = (err as any)?.code;
+        if ((code === "P2034" || code === "P2002") && attempt < MAX_RETRIES - 1) {
           continue;
         }
         throw err;

--- a/src/app/api/user/dashboard/route.ts
+++ b/src/app/api/user/dashboard/route.ts
@@ -8,7 +8,7 @@ import { prismaApp } from "@/lib/db-app";
  * Get team membership for a user
  */
 async function getUserTeamInfo(userId: string) {
-  const membership = await prismaUsers.teamMember.findFirst({
+  const memberships = await prismaUsers.teamMember.findMany({
     where: { userId },
     include: {
       team: {
@@ -24,16 +24,27 @@ async function getUserTeamInfo(userId: string) {
       },
     },
   });
-  
-  if (!membership) return null;
-  
+
+  if (memberships.length === 0) return null;
+
+  // Return first team for backward compat, but expose all
+  const first = memberships[0];
   return {
-    teamId: membership.team.id,
-    teamName: membership.team.name,
-    teamSlug: membership.team.slug,
-    role: membership.role,
-    memberCount: membership.team._count.members,
-    memberIds: membership.team.members.map(m => m.userId),
+    teamId: first.team.id,
+    teamName: first.team.name,
+    teamSlug: first.team.slug,
+    role: first.role,
+    memberCount: first.team._count.members,
+    memberIds: first.team.members.map(m => m.userId),
+    // All teams (aggregated member IDs across all teams)
+    allTeams: memberships.map(m => ({
+      teamId: m.team.id,
+      teamName: m.team.name,
+      teamSlug: m.team.slug,
+      role: m.role,
+      memberCount: m.team._count.members,
+      memberIds: m.team.members.map(member => member.userId),
+    })),
   };
 }
 

--- a/src/app/api/user/dashboard/route.ts
+++ b/src/app/api/user/dashboard/route.ts
@@ -203,38 +203,46 @@ export async function GET() {
     // Team-specific data (if user is in a team)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let teamBlueprints: any[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let allTeamsBlueprints: Record<string, any[]> = {};
     if (teamInfo) {
-      // Get team-shared blueprints (created by team members and marked as TEAM visibility)
-      teamBlueprints = await prismaUsers.userTemplate.findMany({
-        where: {
-          userId: { in: teamInfo.memberIds },
-          visibility: "TEAM",
-          teamId: teamInfo.teamId,
-        },
-        orderBy: { createdAt: "desc" },
-        take: 6,
-        select: {
-          id: true,
-          name: true,
-          type: true,
-          downloads: true,
-          favorites: true,
-          isPublic: true,
-          createdAt: true,
-          user: {
-            select: { name: true, displayName: true },
+      // Fetch blueprints for ALL teams the user belongs to
+      const teamsToQuery = teamInfo.allTeams || [teamInfo];
+      for (const t of teamsToQuery) {
+        const bps = await prismaUsers.userTemplate.findMany({
+          where: {
+            userId: { in: t.memberIds },
+            visibility: "TEAM",
+            teamId: t.teamId,
           },
-        },
-      }).then(templates => templates.map(template => ({
-        id: `bp_${template.id}`,
-        name: template.name,
-        type: template.type,
-        downloads: template.downloads,
-        favorites: template.favorites,
-        isPublic: template.isPublic,
-        createdAt: template.createdAt,
-        author: template.user?.displayName || template.user?.name || "Team member",
-      })));
+          orderBy: { createdAt: "desc" },
+          take: 6,
+          select: {
+            id: true,
+            name: true,
+            type: true,
+            downloads: true,
+            favorites: true,
+            isPublic: true,
+            createdAt: true,
+            user: {
+              select: { name: true, displayName: true },
+            },
+          },
+        }).then(templates => templates.map(template => ({
+          id: `bp_${template.id}`,
+          name: template.name,
+          type: template.type,
+          downloads: template.downloads,
+          favorites: template.favorites,
+          isPublic: template.isPublic,
+          createdAt: template.createdAt,
+          author: template.user?.displayName || template.user?.name || "Team member",
+        })));
+        allTeamsBlueprints[t.teamId] = bps;
+      }
+      // Backward compat: teamBlueprints = first team's blueprints
+      teamBlueprints = allTeamsBlueprints[teamInfo.teamId] || [];
     }
 
     // Enrich activity with template names
@@ -348,6 +356,14 @@ export async function GET() {
         role: teamInfo.role,
         memberCount: teamInfo.memberCount,
       } : null,
+      teams: teamInfo?.allTeams?.map(t => ({
+        id: t.teamId,
+        name: t.teamName,
+        slug: t.teamSlug,
+        role: t.role,
+        memberCount: t.memberCount,
+        blueprints: allTeamsBlueprints[t.teamId] || [],
+      })) || [],
       teamBlueprints: teamInfo ? teamBlueprints : [],
     });
   } catch (error) {

--- a/src/app/api/v1/blueprints/route.ts
+++ b/src/app/api/v1/blueprints/route.ts
@@ -317,7 +317,7 @@ export async function POST(request: NextRequest) {
         // Hierarchy fields
         hierarchyId: validatedHierarchyId,
         parentId: validatedParentId,
-        repositoryPath: repository_path?.trim() || null,
+        repositoryPath: repository_path?.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, "") || null,
         contentChecksum,
       },
       select: {

--- a/src/app/api/v1/blueprints/route.ts
+++ b/src/app/api/v1/blueprints/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";
+import { posix as posixPath } from "path";
 import { prismaUsers } from "@/lib/db-users";
 import { APP_URL } from "@/lib/feature-flags";
 import {
@@ -17,6 +18,14 @@ import {
  */
 function computeChecksum(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+function sanitizeRepositoryPath(input: string | null | undefined): string | null {
+  if (!input?.trim()) return null;
+  // Normalize to posix, strip leading slashes, reject traversal
+  const normalized = posixPath.normalize(input.trim()).replace(/^[/\\]+/, "");
+  if (normalized.startsWith("..") || normalized.includes("/..")) return null;
+  return normalized || null;
 }
 
 /**
@@ -317,7 +326,7 @@ export async function POST(request: NextRequest) {
         // Hierarchy fields
         hierarchyId: validatedHierarchyId,
         parentId: validatedParentId,
-        repositoryPath: repository_path?.trim().replace(/\.\.[/\\]/g, "").replace(/^[/\\]/, "") || null,
+        repositoryPath: sanitizeRepositoryPath(repository_path) || null,
         contentChecksum,
       },
       select: {

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -46,11 +46,12 @@ function SignInContent() {
     message?: string;
   } | null>(null);
 
-  // Handle CLI authentication callback when user is already authenticated
+  // CLI auth requires explicit user consent — no auto-submit
+  const [cliAuthConsented, setCliAuthConsented] = useState(false);
+
   useEffect(() => {
-    if (cliSession && status === "authenticated" && session?.user && !cliAuthComplete && !cliAuthError && !cliAuthProcessing) {
+    if (cliSession && cliAuthConsented && status === "authenticated" && session?.user && !cliAuthComplete && !cliAuthError && !cliAuthProcessing) {
       setCliAuthProcessing(true);
-      // Complete CLI authentication
       fetch("/api/cli-auth/callback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -73,7 +74,37 @@ function SignInContent() {
           setCliAuthProcessing(false);
         });
     }
-  }, [cliSession, status, session, cliAuthComplete, cliAuthError, cliAuthProcessing]);
+  }, [cliSession, cliAuthConsented, status, session, cliAuthComplete, cliAuthError, cliAuthProcessing]);
+
+  // Show CLI consent screen — user must explicitly authorize
+  if (cliSession && status === "authenticated" && session?.user && !cliAuthConsented && !cliAuthComplete && !cliAuthError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-600/10 to-pink-600/10 p-8">
+        <div className="w-full max-w-sm text-center">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
+            <Terminal className="h-10 w-10 text-primary" />
+          </div>
+          <h2 className="mt-6 text-2xl font-bold">Authorize CLI Access</h2>
+          <p className="mt-2 text-muted-foreground">
+            A CLI session is requesting access to your account
+            {session.user.email ? ` (${session.user.email})` : ""}.
+          </p>
+          <p className="mt-4 text-sm text-muted-foreground">
+            This will create an API token for the LynxPrompt CLI. Only proceed if you initiated this from your terminal.
+          </p>
+          <div className="mt-8 flex flex-col gap-3">
+            <Button onClick={() => setCliAuthConsented(true)}>
+              <Terminal className="mr-2 h-4 w-4" />
+              Authorize CLI
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/dashboard">Cancel</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // Show loading state while checking CLI session or processing auth
   if (cliSession && (status === "loading" || cliAuthProcessing)) {

--- a/src/app/auth/sso-complete/page.tsx
+++ b/src/app/auth/sso-complete/page.tsx
@@ -13,10 +13,11 @@ function SSOCompleteContent() {
   useEffect(() => {
     const userId = searchParams.get("userId");
     const email = searchParams.get("email");
+    const teamId = searchParams.get("teamId");
     const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
     const sig = searchParams.get("sig");
 
-    if (!userId || !email || !sig) {
+    if (!userId || !email || !teamId || !sig) {
       setError("Invalid SSO completion parameters.");
       return;
     }
@@ -25,6 +26,7 @@ function SSOCompleteContent() {
     signIn("sso", {
       userId,
       email,
+      teamId,
       sig,
       callbackUrl,
       redirect: true,

--- a/src/app/auth/sso-complete/page.tsx
+++ b/src/app/auth/sso-complete/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
+
+function SSOCompleteContent() {
+  const searchParams = useSearchParams();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const userId = searchParams.get("userId");
+    const email = searchParams.get("email");
+    const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
+    const sig = searchParams.get("sig");
+
+    if (!userId || !email || !sig) {
+      setError("Invalid SSO completion parameters.");
+      return;
+    }
+
+    // Sign in via NextAuth credentials provider with SSO params
+    signIn("sso", {
+      userId,
+      email,
+      sig,
+      callbackUrl,
+      redirect: true,
+    }).catch(() => {
+      setError("Failed to complete SSO sign-in. Please try again.");
+    });
+  }, [searchParams]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-8">
+        <div className="text-center">
+          <p className="text-destructive">{error}</p>
+          <a href="/auth/signin" className="mt-4 inline-block text-primary hover:underline">
+            Back to sign in
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <div className="text-center">
+        <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+        <p className="mt-4 text-muted-foreground">Completing SSO sign-in...</p>
+      </div>
+    </div>
+  );
+}
+
+export default function SSOCompletePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      }
+    >
+      <SSOCompleteContent />
+    </Suspense>
+  );
+}

--- a/src/app/auth/sso-complete/page.tsx
+++ b/src/app/auth/sso-complete/page.tsx
@@ -14,10 +14,11 @@ function SSOCompleteContent() {
     const userId = searchParams.get("userId");
     const email = searchParams.get("email");
     const teamId = searchParams.get("teamId");
+    const nonce = searchParams.get("nonce");
     const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
     const sig = searchParams.get("sig");
 
-    if (!userId || !email || !teamId || !sig) {
+    if (!userId || !email || !teamId || !nonce || !sig) {
       setError("Invalid SSO completion parameters.");
       return;
     }
@@ -27,6 +28,7 @@ function SSOCompleteContent() {
       userId,
       email,
       teamId,
+      nonce,
       sig,
       callbackUrl,
       redirect: true,

--- a/src/app/blueprints/create/page.tsx
+++ b/src/app/blueprints/create/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -100,6 +100,8 @@ export default function ShareBlueprintPage() {
   const { status } = useSession();
   const { enableAI } = useFeatureFlags();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const preselectedTeamId = searchParams.get("teamId");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [name, setName] = useState("");
@@ -174,7 +176,15 @@ export default function ShareBlueprintPage() {
           if (teams.length > 0) {
             setAllTeams(teams);
             setTeamInfo(teams[0]); // backward compat
-            setSelectedTeamId(teams[0].id);
+            // Preselect team from URL param, or fall back to first team
+            const targetTeam = preselectedTeamId
+              ? teams.find((t: { id: string }) => t.id === preselectedTeamId) || teams[0]
+              : teams[0];
+            setSelectedTeamId(targetTeam.id);
+            // Auto-set visibility to TEAM if linked from a team context
+            if (preselectedTeamId && teams.some((t: { id: string }) => t.id === preselectedTeamId)) {
+              setVisibility("TEAM");
+            }
           }
         }
       } catch {

--- a/src/app/blueprints/create/page.tsx
+++ b/src/app/blueprints/create/page.tsx
@@ -262,10 +262,13 @@ export default function ShareBlueprintPage() {
 
   const hasSensitiveData = sensitiveMatches.length > 0 && !sensitiveWarningDismissed;
 
-  // Redirect to sign in if not authenticated
+  // Redirect to sign in if not authenticated, preserving query string
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/auth/signin?callbackUrl=/blueprints/create");
+      const callbackUrl = typeof window !== "undefined"
+        ? window.location.pathname + window.location.search
+        : "/blueprints/create";
+      router.push(`/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`);
     }
   }, [status, router]);
 

--- a/src/app/blueprints/create/page.tsx
+++ b/src/app/blueprints/create/page.tsx
@@ -111,6 +111,8 @@ export default function ShareBlueprintPage() {
   const [visibility, setVisibility] = useState<"PRIVATE" | "TEAM" | "PUBLIC">("PRIVATE");
   const [aiAssisted, setAiAssisted] = useState(false);
   const [teamInfo, setTeamInfo] = useState<{ id: string; name: string; slug: string } | null>(null);
+  const [allTeams, setAllTeams] = useState<{ id: string; name: string; slug: string }[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   
   // Computed isPublic for backwards compatibility
   const isPublic = visibility === "PUBLIC";
@@ -163,19 +165,16 @@ export default function ShareBlueprintPage() {
   useEffect(() => {
     const fetchPlanAndTeam = async () => {
       try {
-        // Fetch billing status
+        // Fetch billing status (includes team memberships)
         const billingRes = await fetch("/api/billing/status");
         if (billingRes.ok) {
           const data = await billingRes.json();
           setUserPlan(data.plan || "FREE");
-        }
-        
-        // Fetch team info (if user is in a team)
-        const dashboardRes = await fetch("/api/user/dashboard");
-        if (dashboardRes.ok) {
-          const data = await dashboardRes.json();
-          if (data.team) {
-            setTeamInfo(data.team);
+          const teams = data.teams || (data.team ? [data.team] : []);
+          if (teams.length > 0) {
+            setAllTeams(teams);
+            setTeamInfo(teams[0]); // backward compat
+            setSelectedTeamId(teams[0].id);
           }
         }
       } catch {
@@ -340,7 +339,7 @@ export default function ShareBlueprintPage() {
           tags,
           isPublic, // For backwards compatibility
           visibility, // New visibility field (PRIVATE, TEAM, PUBLIC)
-          teamId: visibility === "TEAM" ? teamInfo?.id : null, // Set teamId if sharing with team
+          teamId: visibility === "TEAM" ? selectedTeamId : null, // Set teamId if sharing with team
           aiAssisted: isPublic ? aiAssisted : false, // Only relevant if sharing publicly
           showcaseUrl: showcaseUrl.trim() || null,
           turnstileToken: requiresTurnstile ? turnstileToken : undefined,
@@ -1015,21 +1014,34 @@ export default function ShareBlueprintPage() {
                           </label>
                           
                           {/* Team option - only show if user is in a team */}
-                          {teamInfo && (
-                            <label className="flex items-center gap-3 cursor-pointer">
-                              <input
-                                type="radio"
-                                name="visibility"
-                                value="TEAM"
-                                checked={visibility === "TEAM"}
-                                onChange={() => setVisibility("TEAM")}
-                                className="h-4 w-4 border-amber-300 dark:border-amber-400 text-teal-600"
-                              />
-                              <span className="text-sm text-amber-900 dark:text-amber-100">
-                                <Users className="mr-1 inline h-4 w-4" />
-                                Team — Share with {teamInfo.name}
-                              </span>
-                            </label>
+                          {allTeams.length > 0 && (
+                            <div>
+                              <label className="flex items-center gap-3 cursor-pointer">
+                                <input
+                                  type="radio"
+                                  name="visibility"
+                                  value="TEAM"
+                                  checked={visibility === "TEAM"}
+                                  onChange={() => setVisibility("TEAM")}
+                                  className="h-4 w-4 border-amber-300 dark:border-amber-400 text-teal-600"
+                                />
+                                <span className="text-sm text-amber-900 dark:text-amber-100">
+                                  <Users className="mr-1 inline h-4 w-4" />
+                                  Team — Share with {allTeams.length === 1 ? allTeams[0].name : "a team"}
+                                </span>
+                              </label>
+                              {visibility === "TEAM" && allTeams.length > 1 && (
+                                <select
+                                  value={selectedTeamId || ""}
+                                  onChange={(e) => setSelectedTeamId(e.target.value)}
+                                  className="mt-2 ml-7 rounded-md border border-amber-300 dark:border-amber-500 bg-white dark:bg-amber-900/30 px-3 py-1.5 text-sm text-amber-900 dark:text-amber-100"
+                                >
+                                  {allTeams.map((t) => (
+                                    <option key={t.id} value={t.id}>{t.name}</option>
+                                  ))}
+                                </select>
+                              )}
+                            </div>
                           )}
                           
                           {/* Public option */}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -738,7 +738,7 @@ export default function DashboardPage() {
                         Share blueprints with your team by selecting &quot;Team&quot; visibility when creating.
                       </p>
                       <Button asChild className="mt-4" size="sm" variant="outline">
-                        <Link href="/blueprints/create">
+                        <Link href={`/blueprints/create?teamId=${teamData.id}`}>
                           <Upload className="mr-2 h-4 w-4" />
                           Share with Team
                         </Link>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -130,6 +130,15 @@ interface TeamBlueprint {
   author: string;
 }
 
+interface DashboardTeamData {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  memberCount: number;
+  blueprints: TeamBlueprint[];
+}
+
 interface DashboardData {
   stats: DashboardStats;
   myTemplates: MyTemplate[];
@@ -137,6 +146,15 @@ interface DashboardData {
   favoriteTemplates: FavoriteTemplate[];
   hierarchicalBlueprints: HierarchyGroup[];
   teamBlueprints: TeamBlueprint[];
+  teams?: DashboardTeamData[];
+}
+
+interface TeamInfo {
+  id: string;
+  name: string;
+  slug: string;
+  logo?: string | null;
+  role: string;
 }
 
 interface BillingStatus {
@@ -145,13 +163,8 @@ interface BillingStatus {
   isAdmin?: boolean;
   isTeamsUser?: boolean;
   hasActiveSubscription?: boolean;
-  team?: {
-    id: string;
-    name: string;
-    slug: string;
-    logo: string | null;
-    role: string;
-  } | null;
+  team?: TeamInfo | null;
+  teams?: TeamInfo[];
 }
 
 export default function DashboardPage() {
@@ -524,16 +537,16 @@ export default function DashboardPage() {
             </Button>
           </div>
 
-          {/* Teams Banner - Only for Teams users */}
-          {billingStatus?.isTeamsUser && billingStatus?.team && (
-            <div className="mb-8 overflow-hidden rounded-xl border border-teal-500/20 bg-gradient-to-r from-teal-500/10 via-cyan-500/5 to-background">
+          {/* Teams Banner - Show all teams the user belongs to */}
+          {billingStatus?.isTeamsUser && (billingStatus.teams || (billingStatus.team ? [billingStatus.team] : [])).map((t) => (
+            <div key={t.id} className="mb-8 overflow-hidden rounded-xl border border-teal-500/20 bg-gradient-to-r from-teal-500/10 via-cyan-500/5 to-background">
               <div className="p-6">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                   <div className="flex items-center gap-4">
-                    {billingStatus.team.logo ? (
+                    {t.logo ? (
                       <img
-                        src={billingStatus.team.logo}
-                        alt={billingStatus.team.name}
+                        src={t.logo}
+                        alt={t.name}
                         className="h-12 w-12 rounded-lg object-contain bg-muted shadow-lg"
                         style={{ maxWidth: "48px", maxHeight: "48px" }}
                       />
@@ -544,11 +557,11 @@ export default function DashboardPage() {
                     )}
                     <div>
                       <div className="flex items-center gap-2">
-                        <h2 className="text-lg font-semibold">{billingStatus.team.name}</h2>
+                        <h2 className="text-lg font-semibold">{t.name}</h2>
                         <span className="rounded-full bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-800 dark:bg-teal-900/30 dark:text-teal-300">
                           Team
                         </span>
-                        {billingStatus.team.role === "ADMIN" && (
+                        {t.role === "ADMIN" && (
                           <span className="flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
                             <Crown className="h-3 w-3" />
                             Admin
@@ -556,22 +569,22 @@ export default function DashboardPage() {
                         )}
                       </div>
                       <p className="text-sm text-muted-foreground">
-                        {billingStatus.team.role === "ADMIN" 
-                          ? "Manage your team members, billing, and shared blueprints" 
+                        {t.role === "ADMIN"
+                          ? "Manage your team members, billing, and shared blueprints"
                           : "Access shared team blueprints and collaboration features"}
                       </p>
                     </div>
                   </div>
                   <Button asChild variant="outline" className="border-teal-500/30 hover:bg-teal-500/10">
-                    <Link href={`/teams/${billingStatus.team.slug}`}>
+                    <Link href={`/teams/${t.slug}`}>
                       <Users className="mr-2 h-4 w-4 text-teal-500" />
-                      {billingStatus.team.role === "ADMIN" ? "Manage Team" : "View Team"}
+                      {t.role === "ADMIN" ? "Manage Team" : "View Team"}
                     </Link>
                   </Button>
                 </div>
               </div>
             </div>
-          )}
+          ))}
 
           <div className="grid gap-8 lg:grid-cols-3">
             {/* Left Column: Quick Actions + My Templates */}
@@ -691,14 +704,14 @@ export default function DashboardPage() {
                 </div>
               )}
 
-              {/* Team Blueprints - Only for TEAMS users */}
-              {billingStatus?.isTeamsUser && billingStatus?.team && (
-                <div className="mb-8">
+              {/* Team Blueprints - Show per-team sections for all teams */}
+              {billingStatus?.isTeamsUser && (dashboardData?.teams || (billingStatus?.team ? [{ ...billingStatus.team, blueprints: dashboardData?.teamBlueprints || [] }] : [])).map((teamData) => (
+                <div key={teamData.id} className="mb-8">
                   <div className="mb-4 flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <h2 className="text-lg font-semibold">Team Blueprints</h2>
                       <span className="rounded-full bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-800 dark:bg-teal-900/30 dark:text-teal-300">
-                        {billingStatus.team.name}
+                        {teamData.name}
                       </span>
                     </div>
                     <Button variant="ghost" size="sm" asChild>
@@ -715,7 +728,7 @@ export default function DashboardPage() {
                         <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
                       ))}
                     </div>
-                  ) : (!dashboardData?.teamBlueprints || dashboardData.teamBlueprints.length === 0) ? (
+                  ) : (!teamData.blueprints || teamData.blueprints.length === 0) ? (
                     <div className="rounded-lg border border-teal-500/20 bg-gradient-to-r from-teal-500/5 to-background p-8 text-center">
                       <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-teal-500/10">
                         <Users className="h-6 w-6 text-teal-500" />
@@ -734,7 +747,7 @@ export default function DashboardPage() {
                   ) : (
                     <div className="space-y-3">
                       {/* Team-shared blueprints (created by team members) */}
-                      {dashboardData?.teamBlueprints?.map((blueprint) => (
+                      {teamData.blueprints.map((blueprint) => (
                         <div
                           key={blueprint.id}
                           className="flex items-center justify-between rounded-lg border border-teal-500/20 bg-gradient-to-r from-teal-500/5 to-background p-4 transition-colors hover:border-teal-500/40"
@@ -771,7 +784,7 @@ export default function DashboardPage() {
                     </div>
                   )}
                 </div>
-              )}
+              ))}
 
               {/* Hierarchical AGENTS.md (Monorepo support) */}
               <div className="mb-8">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -715,7 +715,7 @@ export default function DashboardPage() {
                       </span>
                     </div>
                     <Button variant="ghost" size="sm" asChild>
-                      <Link href="/blueprints/create">
+                      <Link href={`/blueprints/create?teamId=${teamData.id}`}>
                         <Plus className="mr-2 h-4 w-4" />
                         Share with Team
                       </Link>

--- a/src/app/teams/[slug]/page.tsx
+++ b/src/app/teams/[slug]/page.tsx
@@ -134,7 +134,7 @@ export default function TeamManagementPage() {
       }
 
       // Fetch invitations (admin only)
-      if (billingData.team.role === "ADMIN") {
+      if (matchedTeam.role === "ADMIN") {
         const invitesRes = await fetch(`/api/teams/${teamId}/invitations`);
         if (invitesRes.ok) {
           const invitesData = await invitesRes.json();

--- a/src/app/teams/[slug]/page.tsx
+++ b/src/app/teams/[slug]/page.tsx
@@ -101,20 +101,22 @@ export default function TeamManagementPage() {
       const billingRes = await fetch("/api/billing/status");
       const billingData = await billingRes.json();
 
-      if (!billingData.isTeamsUser || !billingData.team) {
+      const teams = billingData.teams || (billingData.team ? [billingData.team] : []);
+      if (!billingData.isTeamsUser || teams.length === 0) {
         setError("You are not part of any team");
         setLoading(false);
         return;
       }
 
-      if (billingData.team.slug !== slug) {
+      const matchedTeam = teams.find((t: { slug: string }) => t.slug === slug);
+      if (!matchedTeam) {
         setError("Team not found");
         setLoading(false);
         return;
       }
 
-      const teamId = billingData.team.id;
-      setUserRole(billingData.team.role);
+      const teamId = matchedTeam.id;
+      setUserRole(matchedTeam.role);
 
       // Fetch full team details
       const teamRes = await fetch(`/api/teams/${teamId}`);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,6 +14,7 @@ import {
   ENABLE_EMAIL_AUTH,
   ENABLE_PASSKEYS,
   ENABLE_USER_REGISTRATION,
+  ENABLE_SSO,
   APP_NAME,
   APP_URL,
   APP_LOGO_URL,
@@ -23,7 +24,7 @@ import {
   type VerifiedAuthenticationResponse,
 } from "@simplewebauthn/server";
 import { createTransport } from "nodemailer";
-import { createHash } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 // Generate Gravatar URL from email
 function getGravatarUrl(email: string): string {
@@ -292,6 +293,55 @@ function buildProviders(): Provider[] {
             console.error("Passkey authentication error:", error);
             return null;
           }
+        },
+      })
+    );
+  }
+
+  // SSO credentials provider - validates HMAC-signed params from OIDC callback
+  if (ENABLE_SSO) {
+    providers.push(
+      CredentialsProvider({
+        id: "sso",
+        name: "SSO",
+        credentials: {
+          userId: { type: "text" },
+          email: { type: "text" },
+          teamId: { type: "text" },
+          sig: { type: "text" },
+        },
+        async authorize(credentials) {
+          if (!credentials?.userId || !credentials?.email || !credentials?.teamId || !credentials?.sig) {
+            return null;
+          }
+
+          const secret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
+          if (!secret) return null;
+
+          // Verify HMAC signature matches what the OIDC callback generated
+          const signData = `${credentials.userId}:${credentials.email}:${credentials.teamId}`;
+          const expected = createHmac("sha256", secret).update(signData).digest("hex");
+
+          if (credentials.sig !== expected) {
+            return null;
+          }
+
+          // Look up the user - they must already exist (created by OIDC callback)
+          const user = await prismaUsers.user.findUnique({
+            where: { id: credentials.userId },
+            select: { id: true, email: true, name: true, image: true },
+          });
+
+          if (!user || user.email !== credentials.email) {
+            return null;
+          }
+
+          return {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            image: user.image,
+          };
         },
       })
     );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -298,7 +298,7 @@ function buildProviders(): Provider[] {
     );
   }
 
-  // SSO credentials provider - validates HMAC-signed params from OIDC callback
+  // SSO credentials provider - validates HMAC-signed one-time nonce from OIDC callback
   if (ENABLE_SSO) {
     providers.push(
       CredentialsProvider({
@@ -308,22 +308,43 @@ function buildProviders(): Provider[] {
           userId: { type: "text" },
           email: { type: "text" },
           teamId: { type: "text" },
+          nonce: { type: "text" },
           sig: { type: "text" },
         },
         async authorize(credentials) {
-          if (!credentials?.userId || !credentials?.email || !credentials?.teamId || !credentials?.sig) {
+          if (
+            !credentials?.userId || !credentials?.email ||
+            !credentials?.teamId || !credentials?.nonce || !credentials?.sig
+          ) {
             return null;
           }
 
           const secret = process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
           if (!secret) return null;
 
-          // Verify HMAC signature matches what the OIDC callback generated
-          const signData = `${credentials.userId}:${credentials.email}:${credentials.teamId}`;
+          // Verify HMAC signature (includes nonce to bind it)
+          const signData = `${credentials.userId}:${credentials.email}:${credentials.teamId}:${credentials.nonce}`;
           const expected = createHmac("sha256", secret).update(signData).digest("hex");
 
           if (credentials.sig !== expected) {
             return null;
+          }
+
+          // Consume one-time nonce — delete it and verify it existed + hasn't expired
+          try {
+            const token = await prismaUsers.verificationToken.delete({
+              where: {
+                identifier_token: {
+                  identifier: `sso:${credentials.userId}`,
+                  token: credentials.nonce,
+                },
+              },
+            });
+            if (token.expires < new Date()) {
+              return null; // Nonce expired
+            }
+          } catch {
+            return null; // Nonce not found (already consumed or never existed)
           }
 
           // Look up the user - they must already exist (created by OIDC callback)

--- a/src/lib/data/templates.ts
+++ b/src/lib/data/templates.ts
@@ -616,17 +616,13 @@ export async function getTemplateById(
       if (template.userId === userId) {
         hasAccess = true;
       }
-      // Check team-based access
-      else {
-        // Get user's team membership
-        const teamMembership = await prismaUsers.teamMember.findFirst({
-          where: { userId },
+      // Check team-based access across all memberships
+      else if (template.visibility === "TEAM" && template.teamId) {
+        const membership = await prismaUsers.teamMember.findUnique({
+          where: { teamId_userId: { teamId: template.teamId, userId } },
           select: { teamId: true },
         });
-        const userTeamId = teamMembership?.teamId;
-
-        // Check if this is a TEAM visibility blueprint in user's team
-        if (template.visibility === "TEAM" && template.teamId && userTeamId === template.teamId) {
+        if (membership) {
           hasAccess = true;
         }
       }


### PR DESCRIPTION
## Summary

Addresses 5 security findings from a breadth-first review of auth/session, CLI flows, teams/SSO, and content routes.

### HIGH
- **CLI auth session hijacking** — The signin page auto-submitted any `cli_session` query param as soon as the browser was authenticated, allowing an attacker to trick a victim into minting an API token for the attacker's CLI session. Fixed by adding an explicit "Authorize CLI" consent screen.
- **OIDC SSO callback seat bypass + broken redirect** — SSO callback auto-created `TeamMember` without checking `maxSeats`. Also redirected to non-existent `/auth/sso-complete`. Fixed both: added seat enforcement and created the missing page.

### MEDIUM
- **CLI pull path traversal** — `repository_path` from the cloud was joined directly with the output directory, allowing `../` escape. Added `safePath()` guard in CLI and server-side sanitization.
- **Multi-team access resolution** — TEAM visibility used `findFirst({ where: { userId } })` returning an arbitrary team. Replaced with `findUnique` on the composite `teamId_userId` key. Billing endpoint now returns all memberships.

### LOW
- **Download analytics exposure** — GET stats for private/team blueprints were unauthenticated. Added ownership/membership check.

## Files changed
- `src/app/auth/signin/page.tsx` — CLI consent screen
- `src/app/api/auth/sso/callback/oidc/route.ts` — maxSeats check
- `src/app/auth/sso-complete/page.tsx` — new SSO completion page
- `cli/src/commands/pull.ts` — safePath guard
- `src/app/api/v1/blueprints/route.ts` — sanitize repository_path
- `src/lib/data/templates.ts` — multi-team access fix
- `src/app/api/billing/status/route.ts` — return all teams
- `src/app/api/blueprints/[id]/download/route.ts` — auth check on stats

## Test plan
- [ ] CLI login flow: verify consent screen appears, cancelling doesn't create token
- [ ] SSO login with team at max seats: verify rejection
- [ ] `lynxp pull` with `../` in repository_path: verify blocked
- [ ] Multi-team user accessing TEAM blueprint from second team
- [ ] Unauthenticated GET to `/api/blueprints/bp_xxx/download`: verify 401