### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/charts/lynxprompt/.helmignore
+++ b/charts/lynxprompt/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lynxprompt/Chart.yaml
+++ b/charts/lynxprompt/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: lynxprompt
 description: A Helm chart for LynxPrompt - Self-hosted AI IDE configuration hub
 type: application
+kubeVersion: ">=1.21.0-0"
 version: 0.1.0
 appVersion: "2.0.75"
 keywords:

--- a/charts/lynxprompt/Chart.yaml
+++ b/charts/lynxprompt/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: lynxprompt
+description: A Helm chart for LynxPrompt - Self-hosted AI IDE configuration hub
+type: application
+version: 0.1.0
+appVersion: "2.0.75"
+keywords:
+  - lynxprompt
+  - ai
+  - ide
+  - configuration
+  - cursor
+  - claude
+  - copilot
+  - self-hosted
+home: https://lynxprompt.com
+sources:
+  - https://github.com/GeiserX/LynxPrompt
+maintainers:
+  - name: Sergio Fernandez
+    email: acsdesk@protonmail.com
+annotations:
+  category: AI

--- a/charts/lynxprompt/README.md
+++ b/charts/lynxprompt/README.md
@@ -17,6 +17,8 @@ This chart deploys the LynxPrompt web application and an optional bundled Postgr
   - uploads default to a `ReadWriteOnce` PVC
   - concurrent pod starts all run `db push`
 - If you want multiple replicas, use shared/object storage for uploads and move schema management outside normal pod startup.
+- If `postgresql.enabled=false`, set the external database coordinates in `externalDatabase.*` and provide `db-password` via `auth.existingSecret` or `externalDatabase.password`.
+- The chart uses Helm `lookup` to preserve generated secrets on upgrade. For GitOps or `helm template` workflows, prefer `auth.existingSecret` so renders stay deterministic.
 
 ## Secrets
 
@@ -67,6 +69,7 @@ helm upgrade --install lynxprompt ./charts/lynxprompt -f my-values.yaml
 
 - `auth.existingSecret`: reuse credentials from an External Secret or Sealed Secret
 - `waitForDatabase.enabled`: block app startup until PostgreSQL accepts TCP connections
+- `externalDatabase.*`: required when you disable the bundled PostgreSQL
 - `persistence.uploads.existingClaim`: reuse an uploads PVC instead of creating one
 - `app.enableFederation` and `app.federationRegistryUrl`: configure instance federation
 - `extraEnv` / `extraEnvFrom`: inject less common runtime options without forking templates

--- a/charts/lynxprompt/README.md
+++ b/charts/lynxprompt/README.md
@@ -1,0 +1,72 @@
+# LynxPrompt Helm Chart
+
+This chart deploys the LynxPrompt web application and an optional bundled PostgreSQL instance.
+
+## What It Supports
+
+- LynxPrompt web app on a single Deployment
+- Optional bundled PostgreSQL StatefulSet
+- Ingress for browser access
+- Reusable or chart-managed Secret for auth and database credentials
+- Uploads PVC for blog/media assets
+
+## Important Operational Notes
+
+- The container entrypoint runs `prisma db push` for all four LynxPrompt databases on startup.
+- The default chart uses `replicaCount: 1` because:
+  - uploads default to a `ReadWriteOnce` PVC
+  - concurrent pod starts all run `db push`
+- If you want multiple replicas, use shared/object storage for uploads and move schema management outside normal pod startup.
+
+## Secrets
+
+Set `auth.existingSecret` to reuse a pre-created Secret, or let the chart manage one.
+
+Expected keys in the Secret:
+
+- `nextauth-secret`
+- `db-password`
+- optional: `github-client-secret`
+- optional: `google-client-secret`
+- optional: `smtp-password`
+- optional: `anthropic-api-key`
+- optional: `turnstile-secret-key`
+
+## Minimal Example
+
+```yaml
+auth:
+  superadminEmail: admin@example.com
+
+app:
+  url: https://lynxprompt.example.com
+  enableGithubOauth: "true"
+
+oauth:
+  github:
+    clientId: your-client-id
+    clientSecret: your-client-secret
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: lynxprompt.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Install with:
+
+```bash
+helm upgrade --install lynxprompt ./charts/lynxprompt -f my-values.yaml
+```
+
+## Useful Values
+
+- `auth.existingSecret`: reuse credentials from an External Secret or Sealed Secret
+- `waitForDatabase.enabled`: block app startup until PostgreSQL accepts TCP connections
+- `persistence.uploads.existingClaim`: reuse an uploads PVC instead of creating one
+- `app.enableFederation` and `app.federationRegistryUrl`: configure instance federation
+- `extraEnv` / `extraEnvFrom`: inject less common runtime options without forking templates

--- a/charts/lynxprompt/README.md
+++ b/charts/lynxprompt/README.md
@@ -69,6 +69,7 @@ helm upgrade --install lynxprompt ./charts/lynxprompt -f my-values.yaml
 
 - `auth.existingSecret`: reuse credentials from an External Secret or Sealed Secret
 - `waitForDatabase.enabled`: block app startup until PostgreSQL accepts TCP connections
+- `waitForDatabase.timeoutSeconds`: fail startup if the database never becomes reachable instead of looping forever
 - `externalDatabase.*`: required when you disable the bundled PostgreSQL
 - `persistence.uploads.existingClaim`: reuse an uploads PVC instead of creating one
 - `app.enableFederation` and `app.federationRegistryUrl`: configure instance federation

--- a/charts/lynxprompt/templates/NOTES.txt
+++ b/charts/lynxprompt/templates/NOTES.txt
@@ -1,0 +1,25 @@
+LynxPrompt has been deployed successfully!
+
+1. To access LynxPrompt, follow these instructions:
+
+{{- if .Values.ingress.enabled }}
+   LynxPrompt is accessible at:
+
+   {{- range .Values.ingress.hosts }}
+     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (index .paths 0).path }}
+   {{- end }}
+{{- else }}
+   NOTE: The ingress is disabled. Use port-forwarding to access the UI.
+
+   Run the following command to forward the port:
+
+     kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "lynxprompt.fullname" . }} 3000:{{ .Values.service.port }}
+
+   Then access LynxPrompt at: http://127.0.0.1:3000/
+{{- end }}
+
+2. Ensure that the PostgreSQL database is running and accessible. If you enabled the bundled PostgreSQL chart, it should be running within your cluster.
+
+3. The superadmin account will be created on first login using the email configured in auth.superadminEmail.
+
+4. For further configuration, modify the `values.yaml` as needed and upgrade the release.

--- a/charts/lynxprompt/templates/NOTES.txt
+++ b/charts/lynxprompt/templates/NOTES.txt
@@ -21,5 +21,14 @@ LynxPrompt has been deployed successfully!
 2. Ensure that the PostgreSQL database is running and accessible. If you enabled the bundled PostgreSQL chart, it should be running within your cluster.
 
 3. The superadmin account will be created on first login using the email configured in auth.superadminEmail.
+{{- if .Values.auth.existingSecret }}
+   The chart is using the existing Secret {{ .Values.auth.existingSecret }} for NEXTAUTH and database credentials.
+{{- else }}
+   The chart is managing the application Secret {{ include "lynxprompt.secretName" . }}.
+{{- end }}
 
-4. For further configuration, modify the `values.yaml` as needed and upgrade the release.
+4. Health endpoint:
+
+   curl http://127.0.0.1:3000/api/health
+
+5. For further configuration, modify the `values.yaml` as needed and upgrade the release.

--- a/charts/lynxprompt/templates/_helpers.tpl
+++ b/charts/lynxprompt/templates/_helpers.tpl
@@ -71,7 +71,7 @@ Return the PostgreSQL host.
 {{- if .Values.postgresql.enabled -}}
 {{- include "lynxprompt.fullname" . }}-postgresql
 {{- else -}}
-{{- .Values.externalDatabase.host -}}
+{{- required "Set externalDatabase.host when postgresql.enabled=false" .Values.externalDatabase.host -}}
 {{- end -}}
 {{- end -}}
 
@@ -93,7 +93,7 @@ Return the PostgreSQL user.
 {{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.auth.username -}}
 {{- else -}}
-{{- .Values.externalDatabase.user -}}
+{{- required "Set externalDatabase.user when postgresql.enabled=false" .Values.externalDatabase.user -}}
 {{- end -}}
 {{- end -}}
 
@@ -104,7 +104,7 @@ Return the PostgreSQL database name.
 {{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.auth.database -}}
 {{- else -}}
-{{- .Values.externalDatabase.database -}}
+{{- required "Set externalDatabase.database when postgresql.enabled=false" .Values.externalDatabase.database -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/lynxprompt/templates/_helpers.tpl
+++ b/charts/lynxprompt/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lynxprompt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "lynxprompt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lynxprompt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lynxprompt.labels" -}}
+helm.sh/chart: {{ include "lynxprompt.chart" . }}
+{{ include "lynxprompt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lynxprompt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lynxprompt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return the PostgreSQL host.
+*/}}
+{{- define "lynxprompt.postgresql.host" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- include "lynxprompt.fullname" . }}-postgresql
+{{- else -}}
+{{- .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the PostgreSQL port.
+*/}}
+{{- define "lynxprompt.postgresql.port" -}}
+{{- if .Values.postgresql.enabled -}}
+5432
+{{- else -}}
+{{- .Values.externalDatabase.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the PostgreSQL user.
+*/}}
+{{- define "lynxprompt.postgresql.user" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username -}}
+{{- else -}}
+{{- .Values.externalDatabase.user -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the PostgreSQL database name.
+*/}}
+{{- define "lynxprompt.postgresql.database" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lynxprompt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lynxprompt.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/_helpers.tpl
+++ b/charts/lynxprompt/templates/_helpers.tpl
@@ -49,6 +49,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector labels for the web deployment.
+*/}}
+{{- define "lynxprompt.webSelectorLabels" -}}
+{{ include "lynxprompt.selectorLabels" . }}
+app.kubernetes.io/component: web
+{{- end }}
+
+{{/*
+Selector labels for PostgreSQL.
+*/}}
+{{- define "lynxprompt.postgresqlSelectorLabels" -}}
+{{ include "lynxprompt.selectorLabels" . }}
+app.kubernetes.io/component: postgresql
+{{- end }}
+
+{{/*
 Return the PostgreSQL host.
 */}}
 {{- define "lynxprompt.postgresql.host" -}}
@@ -101,4 +117,15 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Secret name for application credentials.
+*/}}
+{{- define "lynxprompt.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- include "lynxprompt.fullname" . -}}
+{{- end -}}
 {{- end }}

--- a/charts/lynxprompt/templates/deployment.yaml
+++ b/charts/lynxprompt/templates/deployment.yaml
@@ -4,27 +4,61 @@ metadata:
   name: {{ include "lynxprompt.fullname" . }}
   labels:
     {{- include "lynxprompt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
+      {{- include "lynxprompt.webSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "lynxprompt.selectorLabels" . | nindent 8 }}
+        {{- include "lynxprompt.webSelectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "lynxprompt.serviceAccountName" . }}
+      {{- if .Values.waitForDatabase.enabled }}
+      initContainers:
+        - name: wait-for-database
+          image: {{ .Values.waitForDatabase.image | quote }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - until nc -z {{ include "lynxprompt.postgresql.host" . | quote }} {{ include "lynxprompt.postgresql.port" . | quote }}; do echo "waiting for database"; sleep 2; done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
@@ -35,10 +69,18 @@ spec:
               value: {{ .Values.app.url | quote }}
             - name: APP_NAME
               value: {{ .Values.app.name | quote }}
+            - name: APP_LOGO_URL
+              value: {{ .Values.app.logoUrl | quote }}
+            - name: CONTACT_EMAIL
+              value: {{ .Values.app.contactEmail | quote }}
+            - name: STATUS_PAGE_URL
+              value: {{ .Values.app.statusPageUrl | quote }}
+            - name: PLATFORM_OWNER_EMAIL
+              value: {{ .Values.app.platformOwnerEmail | quote }}
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: nextauth-secret
             - name: SUPERADMIN_EMAIL
               value: {{ .Values.auth.superadminEmail | quote }}
@@ -53,12 +95,20 @@ spec:
               value: {{ .Values.app.enableGithubOauth | quote }}
             - name: ENABLE_GOOGLE_OAUTH
               value: {{ .Values.app.enableGoogleOauth | quote }}
+            - name: ENABLE_TURNSTILE
+              value: {{ .Values.app.enableTurnstile | quote }}
+            - name: ENABLE_SSO
+              value: {{ .Values.app.enableSso | quote }}
             - name: ENABLE_AI
               value: {{ .Values.app.enableAi | quote }}
             - name: ENABLE_BLOG
               value: {{ .Values.app.enableBlog | quote }}
             - name: ENABLE_SUPPORT_FORUM
               value: {{ .Values.app.enableSupportForum | quote }}
+            - name: ENABLE_FEDERATION
+              value: {{ .Values.app.enableFederation | quote }}
+            - name: FEDERATION_REGISTRY_URL
+              value: {{ .Values.app.federationRegistryUrl | quote }}
             # --- Database: all 4 logical DBs point to the same PostgreSQL instance ---
             {{- $dbHost := include "lynxprompt.postgresql.host" . }}
             {{- $dbPort := include "lynxprompt.postgresql.port" . }}
@@ -67,8 +117,12 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: db-password
+            - name: DB_SSL
+              value: {{ ternary "true" "false" .Values.externalDatabase.ssl.enabled | quote }}
+            - name: DB_SSL_REJECT_UNAUTHORIZED
+              value: {{ ternary "true" "false" .Values.externalDatabase.ssl.rejectUnauthorized | quote }}
             {{- range (list "APP" "USERS" "BLOG" "SUPPORT") }}
             - name: DB_{{ . }}_HOST
               value: {{ $dbHost | quote }}
@@ -88,7 +142,7 @@ spec:
             - name: GITHUB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: github-client-secret
             {{- end }}
             {{- if .Values.oauth.google.clientId }}
@@ -97,8 +151,19 @@ spec:
             - name: GOOGLE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: google-client-secret
+            {{- end }}
+            {{- if .Values.turnstile.siteKey }}
+            - name: NEXT_PUBLIC_TURNSTILE_SITE_KEY
+              value: {{ .Values.turnstile.siteKey | quote }}
+            {{- end }}
+            {{- if .Values.turnstile.secretKey }}
+            - name: TURNSTILE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.secretName" . }}
+                  key: turnstile-secret-key
             {{- end }}
             # --- SMTP (optional) ---
             {{- if .Values.smtp.host }}
@@ -111,27 +176,47 @@ spec:
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: smtp-password
             - name: SMTP_FROM
               value: {{ .Values.smtp.from | quote }}
             - name: SMTP_FROM_NAME
               value: {{ .Values.smtp.fromName | quote }}
             {{- end }}
+            {{- if .Values.analytics.umamiScriptUrl }}
+            - name: UMAMI_SCRIPT_URL
+              value: {{ .Values.analytics.umamiScriptUrl | quote }}
+            {{- end }}
+            {{- if .Values.analytics.websiteId }}
+            - name: NEXT_PUBLIC_UMAMI_WEBSITE_ID
+              value: {{ .Values.analytics.websiteId | quote }}
+            {{- end }}
             # --- AI (optional) ---
             {{- if .Values.ai.anthropicApiKey }}
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: anthropic-api-key
             - name: AI_MODEL
               value: {{ .Values.ai.model | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.httpGet.path }}
+              port: {{ .Values.startupProbe.httpGet.port }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -156,14 +241,25 @@ spec:
           volumeMounts:
             - name: uploads
               mountPath: /app/public/uploads
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.persistence.uploads.enabled }}
+      {{- if or .Values.persistence.uploads.enabled .Values.extraVolumes }}
       volumes:
+        {{- if .Values.persistence.uploads.enabled }}
         - name: uploads
           persistentVolumeClaim:
-            claimName: {{ include "lynxprompt.fullname" . }}-uploads
+            claimName: {{ default (printf "%s-uploads" (include "lynxprompt.fullname" .)) .Values.persistence.uploads.existingClaim }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/lynxprompt/templates/deployment.yaml
+++ b/charts/lynxprompt/templates/deployment.yaml
@@ -39,7 +39,16 @@ spec:
             - /bin/sh
             - -ec
           args:
-            - until nc -z {{ include "lynxprompt.postgresql.host" . | quote }} {{ include "lynxprompt.postgresql.port" . | quote }}; do echo "waiting for database"; sleep 2; done
+            - >-
+              deadline=$(( $(date +%s) + {{ .Values.waitForDatabase.timeoutSeconds }} ));
+              until nc -z {{ include "lynxprompt.postgresql.host" . | quote }} {{ include "lynxprompt.postgresql.port" . | quote }}; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "database did not become ready within {{ .Values.waitForDatabase.timeoutSeconds }} seconds";
+                  exit 1;
+                fi;
+                echo "waiting for database";
+                sleep 2;
+              done
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/lynxprompt/templates/deployment.yaml
+++ b/charts/lynxprompt/templates/deployment.yaml
@@ -1,0 +1,179 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lynxprompt.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lynxprompt.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            # --- App settings ---
+            - name: APP_URL
+              value: {{ .Values.app.url | quote }}
+            - name: NEXTAUTH_URL
+              value: {{ .Values.app.url | quote }}
+            - name: APP_NAME
+              value: {{ .Values.app.name | quote }}
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: nextauth-secret
+            - name: SUPERADMIN_EMAIL
+              value: {{ .Values.auth.superadminEmail | quote }}
+            # --- Feature flags ---
+            - name: ENABLE_USER_REGISTRATION
+              value: {{ .Values.app.enableUserRegistration | quote }}
+            - name: ENABLE_EMAIL_AUTH
+              value: {{ .Values.app.enableEmailAuth | quote }}
+            - name: ENABLE_PASSKEYS
+              value: {{ .Values.app.enablePasskeys | quote }}
+            - name: ENABLE_GITHUB_OAUTH
+              value: {{ .Values.app.enableGithubOauth | quote }}
+            - name: ENABLE_GOOGLE_OAUTH
+              value: {{ .Values.app.enableGoogleOauth | quote }}
+            - name: ENABLE_AI
+              value: {{ .Values.app.enableAi | quote }}
+            - name: ENABLE_BLOG
+              value: {{ .Values.app.enableBlog | quote }}
+            - name: ENABLE_SUPPORT_FORUM
+              value: {{ .Values.app.enableSupportForum | quote }}
+            # --- Database: all 4 logical DBs point to the same PostgreSQL instance ---
+            {{- $dbHost := include "lynxprompt.postgresql.host" . }}
+            {{- $dbPort := include "lynxprompt.postgresql.port" . }}
+            {{- $dbUser := include "lynxprompt.postgresql.user" . }}
+            {{- $dbName := include "lynxprompt.postgresql.database" . }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: db-password
+            {{- range (list "APP" "USERS" "BLOG" "SUPPORT") }}
+            - name: DB_{{ . }}_HOST
+              value: {{ $dbHost | quote }}
+            - name: DB_{{ . }}_PORT
+              value: {{ $dbPort | quote }}
+            - name: DB_{{ . }}_USER
+              value: {{ $dbUser | quote }}
+            - name: DB_{{ . }}_PASSWORD
+              value: "$(DB_PASSWORD)"
+            - name: DB_{{ . }}_NAME
+              value: {{ $dbName | quote }}
+            {{- end }}
+            # --- OAuth (optional) ---
+            {{- if .Values.oauth.github.clientId }}
+            - name: GITHUB_CLIENT_ID
+              value: {{ .Values.oauth.github.clientId | quote }}
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: github-client-secret
+            {{- end }}
+            {{- if .Values.oauth.google.clientId }}
+            - name: GOOGLE_CLIENT_ID
+              value: {{ .Values.oauth.google.clientId | quote }}
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: google-client-secret
+            {{- end }}
+            # --- SMTP (optional) ---
+            {{- if .Values.smtp.host }}
+            - name: SMTP_HOST
+              value: {{ .Values.smtp.host | quote }}
+            - name: SMTP_PORT
+              value: {{ .Values.smtp.port | quote }}
+            - name: SMTP_USER
+              value: {{ .Values.smtp.user | quote }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: smtp-password
+            - name: SMTP_FROM
+              value: {{ .Values.smtp.from | quote }}
+            - name: SMTP_FROM_NAME
+              value: {{ .Values.smtp.fromName | quote }}
+            {{- end }}
+            # --- AI (optional) ---
+            {{- if .Values.ai.anthropicApiKey }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: anthropic-api-key
+            - name: AI_MODEL
+              value: {{ .Values.ai.model | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.readinessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.persistence.uploads.enabled }}
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/public/uploads
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.persistence.uploads.enabled }}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ include "lynxprompt.fullname" . }}-uploads
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lynxprompt/templates/ingress.yaml
+++ b/charts/lynxprompt/templates/ingress.yaml
@@ -5,8 +5,10 @@ metadata:
   name: {{ include "lynxprompt.fullname" . }}
   labels:
     {{- include "lynxprompt.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/lynxprompt/templates/ingress.yaml
+++ b/charts/lynxprompt/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- toYaml .hosts | nindent 8 }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "lynxprompt.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/pdb.yaml
+++ b/charts/lynxprompt/templates/pdb.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/lynxprompt/templates/pdb.yaml
+++ b/charts/lynxprompt/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/lynxprompt/templates/pdb.yaml
+++ b/charts/lynxprompt/templates/pdb.yaml
@@ -14,5 +14,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
+      {{- include "lynxprompt.webSelectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/lynxprompt/templates/pdb.yaml
+++ b/charts/lynxprompt/templates/pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "lynxprompt.fullname" . }}
   labels:
     {{- include "lynxprompt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/lynxprompt/templates/postgresql-service.yaml
+++ b/charts/lynxprompt/templates/postgresql-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}-postgresql
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "lynxprompt.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+{{- end }}

--- a/charts/lynxprompt/templates/postgresql-service.yaml
+++ b/charts/lynxprompt/templates/postgresql-service.yaml
@@ -14,6 +14,5 @@ spec:
       protocol: TCP
       name: postgresql
   selector:
-    {{- include "lynxprompt.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: postgresql
+    {{- include "lynxprompt.postgresqlSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/lynxprompt/templates/postgresql-statefulset.yaml
+++ b/charts/lynxprompt/templates/postgresql-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -71,7 +71,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5

--- a/charts/lynxprompt/templates/postgresql-statefulset.yaml
+++ b/charts/lynxprompt/templates/postgresql-statefulset.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.postgresql.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -44,7 +48,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "lynxprompt.fullname" . }}
+                  name: {{ include "lynxprompt.secretName" . }}
                   key: db-password
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/charts/lynxprompt/templates/postgresql-statefulset.yaml
+++ b/charts/lynxprompt/templates/postgresql-statefulset.yaml
@@ -11,18 +11,31 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: postgresql
+      {{- include "lynxprompt.postgresqlSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "lynxprompt.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: postgresql
+        {{- include "lynxprompt.postgresqlSelectorLabels" . | nindent 8 }}
+        {{- with .Values.postgresql.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.postgresql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: IfNotPresent
+          {{- with .Values.postgresql.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.auth.database | quote }}
@@ -65,11 +78,19 @@ spec:
               mountPath: /var/lib/postgresql/data
           {{- end }}
           resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              memory: 1Gi
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- if .Values.postgresql.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/lynxprompt/templates/postgresql-statefulset.yaml
+++ b/charts/lynxprompt/templates/postgresql-statefulset.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}-postgresql
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "lynxprompt.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "lynxprompt.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "lynxprompt.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lynxprompt.fullname" . }}
+                  key: db-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/pvc.yaml
+++ b/charts/lynxprompt/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.uploads.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}-uploads
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.uploads.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.uploads.size }}
+  {{- if .Values.persistence.uploads.storageClass }}
+  storageClassName: {{ .Values.persistence.uploads.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/pvc.yaml
+++ b/charts/lynxprompt/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.uploads.enabled }}
+{{- if and .Values.persistence.uploads.enabled (not .Values.persistence.uploads.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/lynxprompt/templates/secret.yaml
+++ b/charts/lynxprompt/templates/secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  nextauth-secret: {{ .Values.auth.nextauthSecret | default (randAlphaNum 32) | quote }}
+  {{- if .Values.postgresql.enabled }}
+  db-password: {{ .Values.postgresql.auth.password | default (randAlphaNum 24) | quote }}
+  {{- else }}
+  db-password: {{ .Values.externalDatabase.password | quote }}
+  {{- end }}
+  {{- if .Values.oauth.github.clientSecret }}
+  github-client-secret: {{ .Values.oauth.github.clientSecret | quote }}
+  {{- end }}
+  {{- if .Values.oauth.google.clientSecret }}
+  google-client-secret: {{ .Values.oauth.google.clientSecret | quote }}
+  {{- end }}
+  {{- if .Values.smtp.password }}
+  smtp-password: {{ .Values.smtp.password | quote }}
+  {{- end }}
+  {{- if .Values.ai.anthropicApiKey }}
+  anthropic-api-key: {{ .Values.ai.anthropicApiKey | quote }}
+  {{- end }}

--- a/charts/lynxprompt/templates/secret.yaml
+++ b/charts/lynxprompt/templates/secret.yaml
@@ -1,16 +1,25 @@
+{{- if not .Values.auth.existingSecret }}
+{{- $secretName := include "lynxprompt.secretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingNextauth := "" }}
+{{- $existingDbPassword := "" }}
+{{- if $existing }}
+{{- $existingNextauth = (index $existing.data "nextauth-secret" | default "" | b64dec) }}
+{{- $existingDbPassword = (index $existing.data "db-password" | default "" | b64dec) }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "lynxprompt.fullname" . }}
+  name: {{ $secretName }}
   labels:
     {{- include "lynxprompt.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  nextauth-secret: {{ .Values.auth.nextauthSecret | default (randAlphaNum 32) | quote }}
+  nextauth-secret: {{ .Values.auth.nextauthSecret | default $existingNextauth | default (randAlphaNum 32) | quote }}
   {{- if .Values.postgresql.enabled }}
-  db-password: {{ .Values.postgresql.auth.password | default (randAlphaNum 24) | quote }}
+  db-password: {{ .Values.postgresql.auth.password | default $existingDbPassword | default (randAlphaNum 24) | quote }}
   {{- else }}
-  db-password: {{ .Values.externalDatabase.password | quote }}
+  db-password: {{ .Values.externalDatabase.password | default $existingDbPassword | quote }}
   {{- end }}
   {{- if .Values.oauth.github.clientSecret }}
   github-client-secret: {{ .Values.oauth.github.clientSecret | quote }}
@@ -24,3 +33,7 @@ stringData:
   {{- if .Values.ai.anthropicApiKey }}
   anthropic-api-key: {{ .Values.ai.anthropicApiKey | quote }}
   {{- end }}
+  {{- if .Values.turnstile.secretKey }}
+  turnstile-secret-key: {{ .Values.turnstile.secretKey | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/secret.yaml
+++ b/charts/lynxprompt/templates/secret.yaml
@@ -19,7 +19,7 @@ stringData:
   {{- if .Values.postgresql.enabled }}
   db-password: {{ .Values.postgresql.auth.password | default $existingDbPassword | default (randAlphaNum 24) | quote }}
   {{- else }}
-  db-password: {{ .Values.externalDatabase.password | default $existingDbPassword | quote }}
+  db-password: {{ .Values.externalDatabase.password | default $existingDbPassword | required "Set externalDatabase.password or auth.existingSecret when postgresql.enabled=false" | quote }}
   {{- end }}
   {{- if .Values.oauth.github.clientSecret }}
   github-client-secret: {{ .Values.oauth.github.clientSecret | quote }}

--- a/charts/lynxprompt/templates/service.yaml
+++ b/charts/lynxprompt/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "lynxprompt.fullname" . }}
   labels:
     {{- include "lynxprompt.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "lynxprompt.selectorLabels" . | nindent 4 }}
+    {{- include "lynxprompt.webSelectorLabels" . | nindent 4 }}

--- a/charts/lynxprompt/templates/service.yaml
+++ b/charts/lynxprompt/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lynxprompt.fullname" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lynxprompt.selectorLabels" . | nindent 4 }}

--- a/charts/lynxprompt/templates/serviceaccount.yaml
+++ b/charts/lynxprompt/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/lynxprompt/templates/serviceaccount.yaml
+++ b/charts/lynxprompt/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lynxprompt.serviceAccountName" . }}
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lynxprompt/templates/tests/test-connection.yaml
+++ b/charts/lynxprompt/templates/tests/test-connection.yaml
@@ -9,9 +9,21 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  automountServiceAccountToken: false
   containers:
     - name: wget
-      image: busybox:latest
-      command: ['wget']
-      args: ['--spider', '--quiet', 'http://{{ include "lynxprompt.fullname" . }}:{{ .Values.service.port }}']
+      image: busybox:1.36.1
+      command:
+        - /bin/sh
+        - -ec
+      args:
+        - wget --spider --quiet "http://{{ include "lynxprompt.fullname" . }}:{{ .Values.service.port }}/api/health"
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
   restartPolicy: Never

--- a/charts/lynxprompt/templates/tests/test-connection.yaml
+++ b/charts/lynxprompt/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "lynxprompt.fullname" . }}-test-connection"
+  labels:
+    {{- include "lynxprompt.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  containers:
+    - name: wget
+      image: busybox:latest
+      command: ['wget']
+      args: ['--spider', '--quiet', 'http://{{ include "lynxprompt.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/lynxprompt/values.schema.json
+++ b/charts/lynxprompt/values.schema.json
@@ -1,0 +1,515 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "nextauthSecret": {
+          "type": "string"
+        },
+        "superadminEmail": {
+          "type": "string"
+        }
+      }
+    },
+    "app": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "logoUrl": {
+          "type": "string"
+        },
+        "contactEmail": {
+          "type": "string"
+        },
+        "statusPageUrl": {
+          "type": "string"
+        },
+        "platformOwnerEmail": {
+          "type": "string"
+        },
+        "enableUserRegistration": {
+          "type": "string"
+        },
+        "enableEmailAuth": {
+          "type": "string"
+        },
+        "enablePasskeys": {
+          "type": "string"
+        },
+        "enableGithubOauth": {
+          "type": "string"
+        },
+        "enableGoogleOauth": {
+          "type": "string"
+        },
+        "enableTurnstile": {
+          "type": "string"
+        },
+        "enableSso": {
+          "type": "string"
+        },
+        "enableAi": {
+          "type": "string"
+        },
+        "enableBlog": {
+          "type": "string"
+        },
+        "enableSupportForum": {
+          "type": "string"
+        },
+        "enableFederation": {
+          "type": "string"
+        },
+        "federationRegistryUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "oauth": {
+      "type": "object",
+      "properties": {
+        "github": {
+          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            }
+          }
+        },
+        "google": {
+          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "turnstile": {
+      "type": "object",
+      "properties": {
+        "siteKey": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string"
+        }
+      }
+    },
+    "analytics": {
+      "type": "object",
+      "properties": {
+        "umamiScriptUrl": {
+          "type": "string"
+        },
+        "websiteId": {
+          "type": "string"
+        }
+      }
+    },
+    "smtp": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string"
+        },
+        "fromName": {
+          "type": "string"
+        }
+      }
+    },
+    "ai": {
+      "type": "object",
+      "properties": {
+        "anthropicApiKey": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object"
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "ssl": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "rejectUnauthorized": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "waitForDatabase": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "string"
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "uploads": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": ["integer", "string"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"]
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object"
+    }
+  }
+}

--- a/charts/lynxprompt/values.schema.json
+++ b/charts/lynxprompt/values.schema.json
@@ -365,6 +365,10 @@
         },
         "image": {
           "type": "string"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },

--- a/charts/lynxprompt/values.schema.json
+++ b/charts/lynxprompt/values.schema.json
@@ -405,6 +405,17 @@
         "enabled": {
           "type": "boolean"
         },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
         "periodSeconds": {
           "type": "integer",
           "minimum": 1
@@ -424,6 +435,33 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },
@@ -432,6 +470,33 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },

--- a/charts/lynxprompt/values.yaml
+++ b/charts/lynxprompt/values.yaml
@@ -1,13 +1,19 @@
+nameOverride: ""
+fullnameOverride: ""
+
 image:
   repository: drumsergio/lynxprompt
   pullPolicy: IfNotPresent
   tag: "2.0.75"
+
+imagePullSecrets: []
 
 replicaCount: 1
 
 service:
   type: ClusterIP
   port: 3000
+  annotations: {}
 
 ingress:
   enabled: false
@@ -17,24 +23,33 @@ ingress:
     - host: lynxprompt.local
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
   tls: []
 
 auth:
-  nextauthSecret: ""  # Generate with: openssl rand -base64 32
+  existingSecret: ""
+  nextauthSecret: ""
   superadminEmail: ""
 
 app:
   url: "http://localhost:3000"
   name: "LynxPrompt"
+  logoUrl: ""
+  contactEmail: ""
+  statusPageUrl: ""
+  platformOwnerEmail: ""
   enableUserRegistration: "true"
   enableEmailAuth: "true"
   enablePasskeys: "true"
   enableGithubOauth: "false"
   enableGoogleOauth: "false"
+  enableTurnstile: "false"
+  enableSso: "false"
   enableAi: "false"
   enableBlog: "false"
   enableSupportForum: "false"
+  enableFederation: "true"
+  federationRegistryUrl: "https://lynxprompt.com"
 
 oauth:
   github:
@@ -43,6 +58,14 @@ oauth:
   google:
     clientId: ""
     clientSecret: ""
+
+turnstile:
+  siteKey: ""
+  secretKey: ""
+
+analytics:
+  umamiScriptUrl: ""
+  websiteId: ""
 
 smtp:
   host: ""
@@ -63,28 +86,48 @@ postgresql:
     tag: "17-alpine"
   auth:
     username: lynxprompt
-    password: changeme
+    password: ""
     database: lynxprompt
   persistence:
     enabled: true
     size: 8Gi
     storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
-# Used when postgresql.enabled is false (bring your own PostgreSQL)
 externalDatabase:
   host: ""
   port: 5432
   user: ""
   password: ""
   database: ""
+  ssl:
+    enabled: false
+    rejectUnauthorized: true
+
+waitForDatabase:
+  enabled: true
+  image: busybox:1.36.1
 
 persistence:
   uploads:
     enabled: true
+    existingClaim: ""
     size: 5Gi
     accessModes:
       - ReadWriteOnce
-    # storageClass: ""
+    storageClass: ""
 
 resources:
   requests:
@@ -93,10 +136,19 @@ resources:
   limits:
     memory: 2Gi
 
+startupProbe:
+  enabled: true
+  httpGet:
+    path: /api/health
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
 livenessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /api/health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -106,9 +158,9 @@ livenessProbe:
 readinessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /api/health
     port: http
-  initialDelaySeconds: 15
+  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
@@ -135,8 +187,14 @@ podDisruptionBudget:
   minAvailable: 1
   # maxUnavailable: 1
 
+podAnnotations: {}
+podLabels: {}
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumes: []
+extraVolumeMounts: []
+
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/charts/lynxprompt/values.yaml
+++ b/charts/lynxprompt/values.yaml
@@ -119,6 +119,7 @@ externalDatabase:
 waitForDatabase:
   enabled: true
   image: busybox:1.36.1
+  timeoutSeconds: 300
 
 persistence:
   uploads:

--- a/charts/lynxprompt/values.yaml
+++ b/charts/lynxprompt/values.yaml
@@ -1,0 +1,142 @@
+image:
+  repository: drumsergio/lynxprompt
+  pullPolicy: IfNotPresent
+  tag: "2.0.75"
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: lynxprompt.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+auth:
+  nextauthSecret: ""  # Generate with: openssl rand -base64 32
+  superadminEmail: ""
+
+app:
+  url: "http://localhost:3000"
+  name: "LynxPrompt"
+  enableUserRegistration: "true"
+  enableEmailAuth: "true"
+  enablePasskeys: "true"
+  enableGithubOauth: "false"
+  enableGoogleOauth: "false"
+  enableAi: "false"
+  enableBlog: "false"
+  enableSupportForum: "false"
+
+oauth:
+  github:
+    clientId: ""
+    clientSecret: ""
+  google:
+    clientId: ""
+    clientSecret: ""
+
+smtp:
+  host: ""
+  port: "587"
+  user: ""
+  password: ""
+  from: "noreply@localhost"
+  fromName: "LynxPrompt"
+
+ai:
+  anthropicApiKey: ""
+  model: "claude-3-5-haiku-latest"
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "17-alpine"
+  auth:
+    username: lynxprompt
+    password: changeme
+    database: lynxprompt
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""
+
+# Used when postgresql.enabled is false (bring your own PostgreSQL)
+externalDatabase:
+  host: ""
+  port: 5432
+  user: ""
+  password: ""
+  database: ""
+
+persistence:
+  uploads:
+    enabled: true
+    size: 5Gi
+    accessModes:
+      - ReadWriteOnce
+    # storageClass: ""
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 2Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Helm Chart: LynxPrompt

Kubernetes deployment via Helm with:
- **Deployment** for the Next.js app
- **PostgreSQL StatefulSet** (postgres:17-alpine) — all 4 logical databases (APP, USERS, BLOG, SUPPORT) share one instance
- **Ingress** (optional), **PDB** (optional), **ServiceAccount**, **PVC** for uploads

### Configuration
- Auth secrets (NEXTAUTH_SECRET, DB password) managed via K8s Secret
- Optional OAuth (GitHub, Google), SMTP, AI (Anthropic) — all togglable via values
- Feature flags for registration, passkeys, blog, support forum
- External database support (`externalDatabase.*` when `postgresql.enabled=false`)

### Testing
- `helm lint` passes clean
- Deployed and tested on kind — both pods running (app + postgresql), `helm test` succeeded
- App successfully connects to PostgreSQL, runs Prisma migrations, and serves HTTP

### Quick start
```bash
helm install lynxprompt ./charts/lynxprompt \
  --set auth.nextauthSecret=$(openssl rand -base64 32) \
  --set postgresql.auth.password=my-secure-password
```