### PR TITLE
fix: add guardrails for scaling and ephemeral PostgreSQL

### DIFF
--- a/charts/lynxprompt/templates/deployment.yaml
+++ b/charts/lynxprompt/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and (gt (int .Values.replicaCount) 1) .Values.persistence.uploads.enabled (not .Values.persistence.uploads.existingClaim) (has "ReadWriteOnce" .Values.persistence.uploads.accessModes) }}
+{{- fail "replicaCount > 1 with a ReadWriteOnce uploads PVC will cause pending pods. Set persistence.uploads.accessModes to [ReadWriteMany] or provide an existingClaim with RWX support." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/lynxprompt/templates/postgresql-statefulset.yaml
+++ b/charts/lynxprompt/templates/postgresql-statefulset.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.postgresql.enabled }}
+{{- if not .Values.postgresql.persistence.enabled }}
+{{- fail "postgresql.persistence.enabled=false will use ephemeral container storage — all data is lost on pod restart. Set postgresql.persistence.enabled=true or use externalDatabase." }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
## Summary
- Fail at template time if `replicaCount > 1` with a ReadWriteOnce uploads PVC (would cause pending pods or broken rollouts)
- Fail at template time if `postgresql.persistence.enabled=false` (would silently lose all data on pod restart)

## Test plan
- [ ] `helm template --set replicaCount=3` produces a clear error about RWO + multi-replica
- [ ] `helm template --set postgresql.persistence.enabled=false` produces a clear error about ephemeral storage
- [ ] Default values render cleanly