### PR TITLE
ci: fix Docker semver tags and chart appVersion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,16 @@ name: Docker Publish
 
 on:
   push:
-    tags:
-      - 'app-v*'
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'packages/**'
+      - 'public/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'Dockerfile'
+      - '.github/workflows/docker-publish.yml'
   workflow_dispatch:
 
 env:
@@ -19,6 +27,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Get app version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -39,7 +51,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
             type=raw,value=latest
-            type=match,pattern=app-v(.*),group=1
+            type=raw,value=${{ steps.version.outputs.version }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/charts/lynxprompt/Chart.yaml
+++ b/charts/lynxprompt/Chart.yaml
@@ -3,8 +3,8 @@ name: lynxprompt
 description: A Helm chart for LynxPrompt - Self-hosted AI IDE configuration hub
 type: application
 kubeVersion: ">=1.21.0-0"
-version: 0.1.0
-appVersion: "2.0.76"
+version: 0.1.1
+appVersion: "2.0.75"
 keywords:
   - lynxprompt
   - ai

--- a/charts/lynxprompt/values.yaml
+++ b/charts/lynxprompt/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 image:
   repository: drumsergio/lynxprompt
   pullPolicy: IfNotPresent
-  tag: "2.0.76"
+  tag: "2.0.75"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Summary
- **docker-publish.yml**: Switch from `app-v*` tag trigger to push-to-main with path filters. The `release.yml` pushes tags with `GITHUB_TOKEN` which can't trigger other workflows (GitHub anti-loop protection). Now reads version directly from `package.json`.
- **Chart**: Fix appVersion `2.0.76` → `2.0.75` (matching actual `package.json`), bump chart to `0.1.1`

Fixes ArtifactHub security scan: `image not found drumsergio/lynxprompt:2.0.76`