### PR TITLE
Add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   <a href="https://github.com/GeiserX/lynxprompt-action"><img src="https://img.shields.io/badge/GitHub_Action-v1-2088FF?style=flat-square&logo=githubactions&logoColor=white" alt="GitHub Action"></a>
   <a href="https://aur.archlinux.org/packages/lynxprompt"><img src="https://img.shields.io/aur/version/lynxprompt?style=flat-square&logo=archlinux&label=AUR" alt="AUR"></a>
   <a href="https://snapcraft.io/lynxprompt"><img src="https://snapcraft.io/lynxprompt/badge.svg" alt="Snap"></a>
+  <a href="https://codecov.io/gh/GeiserX/LynxPrompt"><img src="https://codecov.io/gh/GeiserX/LynxPrompt/graph/badge.svg" alt="codecov"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Add Codecov coverage badge alongside existing badges in the README.