### PR TITLE
fix(ci): add missing tool setup for self-hosted runner workflows

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -24,6 +24,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Ensure jq is available
+        run: |
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          fi
+
       - name: Generate version
         id: version
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Generate version
         id: version
         run: |


### PR DESCRIPTION
## Summary

- Add `actions/setup-node@v4` to `deploy-development.yml` and `deploy-production.yml` — both run on the self-hosted geiserback runner which lacks pre-installed Node.js, but use `node -p` to read `package.json` version
- Add `jq` availability check to `deploy-development.yml` — the health check step parses JSON with `jq` which may not be installed on the bare runner

## Context

Audited all 10 workflow files in `.github/workflows/`. Only the two deployment workflows (`deploy-development.yml`, `deploy-production.yml`) use `runs-on: [self-hosted, linux, x64, geiserback]`. The remaining 8 workflows use `ubuntu-latest` (GitHub-hosted) where Node.js and jq are pre-installed.

### Workflows audited (no issues)
- `ci.yml` — `ubuntu-latest`, has `setup-node`
- `cli-tests.yml` — `ubuntu-latest`, has `setup-node`
- `docker-publish.yml` — `ubuntu-latest`, uses Docker actions
- `dockerhub-description.yml` — `ubuntu-latest`, no tools needed
- `publish-cli.yml` — `ubuntu-latest`, has `setup-node`
- `release-chart.yml` — `ubuntu-latest`, uses Helm action
- `release.yml` — `ubuntu-latest`, has `setup-node` where needed
- `stale.yml` — `ubuntu-latest`, uses stale action only

## Test plan
- [ ] Verify `deploy-development.yml` passes on next push to `develop`
- [ ] Verify `deploy-production.yml` passes on next push to `main`