### PR TITLE
ci: add tests/ and vitest.config to CI path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
       - 'packages/**'
       - 'prisma/**'
       - 'public/**'
+      - 'tests/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
+      - 'vitest.config.*'
       - 'next.config.*'
       - '.github/workflows/ci.yml'
   pull_request:
@@ -20,9 +22,11 @@ on:
       - 'packages/**'
       - 'prisma/**'
       - 'public/**'
+      - 'tests/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
+      - 'vitest.config.*'
       - 'next.config.*'
       - '.github/workflows/ci.yml'
 


### PR DESCRIPTION
## Summary
- CI workflow path filters excluded `tests/**` and `vitest.config.*`, so the CI test job never ran
- This adds both paths to push and pull_request triggers

## Test plan
- [ ] CI runs on this PR (since it changes `.github/workflows/ci.yml`)
- [ ] Codecov report is generated after merge