### PR TITLE
test: boost coverage to 92% for Codecov 90% target

### DIFF
--- a/tests/lib/auth-sso-flow.test.ts
+++ b/tests/lib/auth-sso-flow.test.ts
@@ -1,0 +1,261 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "crypto";
+
+// Mock all dependencies before importing auth
+const mockFindUnique = vi.fn();
+const mockFindFirst = vi.fn();
+const mockUpdate = vi.fn();
+const mockUpdateMany = vi.fn();
+const mockAuthenticatorUpdate = vi.fn();
+const mockAccountFindUnique = vi.fn();
+const mockAccountUpdate = vi.fn();
+const mockVerificationTokenDelete = vi.fn();
+const mockTeamMemberUpdateMany = vi.fn();
+
+function setupBaseMocks() {
+  vi.doMock("@/lib/db-users", () => ({
+    prismaUsers: {
+      user: {
+        findUnique: (...args) => mockFindUnique(...args),
+        findFirst: (...args) => mockFindFirst(...args),
+        update: (...args) => mockUpdate(...args),
+        updateMany: (...args) => mockUpdateMany(...args),
+      },
+      authenticator: {
+        update: (...args) => mockAuthenticatorUpdate(...args),
+      },
+      account: {
+        findUnique: (...args) => mockAccountFindUnique(...args),
+        update: (...args) => mockAccountUpdate(...args),
+      },
+      teamMember: {
+        findUnique: vi.fn(),
+        updateMany: (...args) => mockTeamMemberUpdateMany(...args),
+      },
+      verificationToken: {
+        delete: (...args) => mockVerificationTokenDelete(...args),
+      },
+    },
+  }));
+  vi.doMock("next-auth/providers/github", () => ({
+    default: vi.fn(() => ({ id: "github", name: "GitHub" })),
+  }));
+  vi.doMock("next-auth/providers/google", () => ({
+    default: vi.fn(() => ({ id: "google", name: "Google" })),
+  }));
+  vi.doMock("next-auth/providers/email", () => ({
+    default: vi.fn((opts) => ({ id: "email", name: "Email", sendVerificationRequest: opts.sendVerificationRequest })),
+  }));
+  vi.doMock("next-auth/providers/credentials", () => ({
+    default: vi.fn((opts) => ({
+      id: opts.id,
+      name: opts.name,
+      authorize: opts.authorize,
+    })),
+  }));
+  vi.doMock("@auth/prisma-adapter", () => ({
+    PrismaAdapter: vi.fn(() => ({})),
+  }));
+  vi.doMock("@simplewebauthn/server", () => ({
+    verifyAuthenticationResponse: vi.fn(),
+  }));
+  vi.doMock("nodemailer", () => ({
+    createTransport: vi.fn(() => ({
+      sendMail: vi.fn().mockResolvedValue({ rejected: [] }),
+    })),
+  }));
+}
+
+describe("SSO authorize - full flow", () => {
+  const secret = "test-secret-key";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.NEXTAUTH_SECRET = secret;
+  });
+
+  async function getSsoProvider() {
+    vi.doMock("@/lib/feature-flags", () => ({
+      ENABLE_GITHUB_OAUTH: false,
+      ENABLE_GOOGLE_OAUTH: false,
+      ENABLE_EMAIL_AUTH: false,
+      ENABLE_PASSKEYS: false,
+      ENABLE_USER_REGISTRATION: true,
+      ENABLE_SSO: true,
+      APP_NAME: "TestApp",
+      APP_URL: "https://test.example.com",
+      APP_LOGO_URL: "",
+    }));
+    setupBaseMocks();
+    const { authOptions } = await import("@/lib/auth");
+    return authOptions.providers.find((p) => p.id === "sso");
+  }
+
+  it("returns null when NEXTAUTH_SECRET is not set", async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    delete process.env.AUTH_SECRET;
+    const provider = await getSsoProvider();
+
+    const result = await provider.authorize({
+      userId: "u1",
+      email: "test@test.com",
+      teamId: "t1",
+      nonce: "n1",
+      sig: "some-sig",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when HMAC signature does not match", async () => {
+    const provider = await getSsoProvider();
+
+    const result = await provider.authorize({
+      userId: "u1",
+      email: "test@test.com",
+      teamId: "t1",
+      nonce: "n1",
+      sig: "invalid-signature",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when nonce is not found (already consumed)", async () => {
+    const provider = await getSsoProvider();
+
+    const userId = "u1";
+    const email = "test@test.com";
+    const teamId = "t1";
+    const nonce = "nonce-abc";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", secret).update(signData).digest("hex");
+
+    // Nonce deletion throws (not found)
+    mockVerificationTokenDelete.mockRejectedValue(new Error("Record not found"));
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when nonce is expired", async () => {
+    const provider = await getSsoProvider();
+
+    const userId = "u1";
+    const email = "test@test.com";
+    const teamId = "t1";
+    const nonce = "nonce-expired";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", secret).update(signData).digest("hex");
+
+    // Nonce found but expired
+    mockVerificationTokenDelete.mockResolvedValue({
+      expires: new Date("2020-01-01"), // Past date
+    });
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user not found in database", async () => {
+    const provider = await getSsoProvider();
+
+    const userId = "u-missing";
+    const email = "test@test.com";
+    const teamId = "t1";
+    const nonce = "nonce-valid";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", secret).update(signData).digest("hex");
+
+    mockVerificationTokenDelete.mockResolvedValue({
+      expires: new Date(Date.now() + 3600000), // 1 hour from now
+    });
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user email does not match", async () => {
+    const provider = await getSsoProvider();
+
+    const userId = "u1";
+    const email = "test@test.com";
+    const teamId = "t1";
+    const nonce = "nonce-mismatch";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", secret).update(signData).digest("hex");
+
+    mockVerificationTokenDelete.mockResolvedValue({
+      expires: new Date(Date.now() + 3600000),
+    });
+    mockFindUnique.mockResolvedValue({
+      id: "u1",
+      email: "different@test.com", // Mismatched email
+      name: "User",
+      image: null,
+    });
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).toBeNull();
+  });
+
+  it("returns user on successful SSO authorization", async () => {
+    const provider = await getSsoProvider();
+
+    const userId = "u1";
+    const email = "test@test.com";
+    const teamId = "t1";
+    const nonce = "nonce-good";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", secret).update(signData).digest("hex");
+
+    mockVerificationTokenDelete.mockResolvedValue({
+      expires: new Date(Date.now() + 3600000),
+    });
+    mockFindUnique.mockResolvedValue({
+      id: "u1",
+      email: "test@test.com",
+      name: "SSO User",
+      image: "https://example.com/avatar.png",
+    });
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("u1");
+    expect(result.email).toBe("test@test.com");
+    expect(result.name).toBe("SSO User");
+    expect(result.image).toBe("https://example.com/avatar.png");
+  });
+
+  it("uses AUTH_SECRET as fallback when NEXTAUTH_SECRET is not set", async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    process.env.AUTH_SECRET = "auth-secret-fallback";
+
+    vi.resetModules();
+    const provider = await getSsoProvider();
+
+    const userId = "u2";
+    const email = "auth@test.com";
+    const teamId = "t2";
+    const nonce = "nonce-auth";
+    const signData = `${userId}:${email}:${teamId}:${nonce}`;
+    const sig = createHmac("sha256", "auth-secret-fallback").update(signData).digest("hex");
+
+    mockVerificationTokenDelete.mockResolvedValue({
+      expires: new Date(Date.now() + 3600000),
+    });
+    mockFindUnique.mockResolvedValue({
+      id: "u2",
+      email: "auth@test.com",
+      name: "Auth User",
+      image: null,
+    });
+
+    const result = await provider.authorize({ userId, email, teamId, nonce, sig });
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("u2");
+
+    delete process.env.AUTH_SECRET;
+  });
+});

--- a/tests/lib/file-generator-coverage.test.ts
+++ b/tests/lib/file-generator-coverage.test.ts
@@ -1,0 +1,197 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/feature-flags", () => ({
+  APP_NAME: "LynxPrompt",
+  APP_URL: "https://lynxprompt.com",
+}));
+
+vi.mock("@/lib/platforms", () => ({
+  PLATFORM_FILES: {
+    cursor: ".cursor/rules/",
+    claude: "CLAUDE.md",
+    copilot: ".github/copilot-instructions.md",
+    windsurf: ".windsurfrules",
+    universal: "AGENTS.md",
+    antigravity: "GEMINI.md",
+    aider: "AIDER.md",
+    continue: ".continue/config.json",
+    cody: ".cody/config.json",
+    tabnine: ".tabnine.yaml",
+    supermaven: ".supermaven/config.json",
+    codegpt: ".codegpt/config.json",
+    void: ".void/config.json",
+    zed: ".zed/instructions.md",
+    cline: ".clinerules",
+    goose: ".goosehints",
+    amazonq: ".amazonq/rules/",
+    roocode: ".roo/rules/",
+    warp: "WARP.md",
+    "gemini-cli": "GEMINI.md",
+    trae: ".trae/rules/",
+    firebase: ".idx/",
+    augment: ".augment/rules/",
+    kilocode: ".kilocode/rules/",
+    junie: ".junie/guidelines.md",
+    kiro: ".kiro/steering/",
+    openhands: ".openhands/microagents/repo.md",
+    crush: "CRUSH.md",
+    opencode: "opencode.json",
+    firebender: "firebender.json",
+  },
+  getPlatform: (id: string) => ({ id, name: id, file: `.${id}` }),
+}));
+
+import {
+  generateAllFiles,
+  generateConfigFiles,
+  downloadZip,
+  downloadConfigFile,
+} from "@/lib/file-generator";
+
+const baseUser = {
+  name: "Test User",
+  displayName: "Test User",
+  email: "test@test.com",
+  tier: "max" as const,
+  skillLevel: "intermediate",
+  persona: null,
+  subscriptionPlan: "MAX",
+};
+
+const baseConfig = {
+  projectName: "TestProject",
+  projectDescription: "A test project",
+  languages: ["typescript"] as string[],
+  frameworks: ["nextjs"] as string[],
+  additionalFeedback: "",
+  isPublic: true,
+  repoUrl: "https://github.com/test/repo",
+  repoHost: "github",
+  license: "mit",
+  funding: false,
+  cicd: ["github_actions"],
+  aiBehaviorRules: [] as string[],
+};
+
+// ============================================================================
+// generateConfigFiles (lines 4538-4548)
+// ============================================================================
+describe("generateConfigFiles", () => {
+  it("returns a Blob with content for valid config", async () => {
+    const blob = await generateConfigFiles(
+      {
+        ...baseConfig,
+        platform: "cursor",
+      },
+      baseUser
+    );
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(0);
+  });
+
+  it("returns empty blob when no files generated (unknown platform)", async () => {
+    const blob = await generateConfigFiles(
+      {
+        ...baseConfig,
+        platform: "nonexistent-platform-xyz",
+      } as any,
+      baseUser
+    );
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// downloadZip (lines 4552-4563)
+// ============================================================================
+describe("downloadZip", () => {
+  let mockElement;
+
+  beforeEach(() => {
+    mockElement = {
+      href: "",
+      download: "",
+      click: vi.fn(),
+    };
+    vi.spyOn(document, "createElement").mockReturnValue(mockElement as any);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => mockElement as any);
+    vi.spyOn(document.body, "removeChild").mockImplementation(() => mockElement as any);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test-url");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  });
+
+  it("creates a download link and triggers click", () => {
+    const blob = new Blob(["test content"], { type: "text/plain" });
+    downloadZip(blob, "my-project");
+
+    expect(document.createElement).toHaveBeenCalledWith("a");
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(mockElement.click).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-url");
+  });
+
+  it("uses default fileName when no files array provided", () => {
+    const blob = new Blob(["test content"], { type: "text/plain" });
+    downloadZip(blob, "my-project");
+
+    expect(mockElement.download).toBe("ai-config.md");
+  });
+
+  it("uses fileName from files array when provided via arguments", () => {
+    const blob = new Blob(["test content"], { type: "text/plain" });
+    const files = [{ fileName: "CLAUDE.md", content: "test", platform: "claude" }];
+    // downloadZip reads files from arguments[2]
+    downloadZip(blob, "my-project", files as any);
+
+    expect(mockElement.download).toBe("CLAUDE.md");
+  });
+});
+
+// ============================================================================
+// downloadConfigFile (lines 4567-4578)
+// ============================================================================
+describe("downloadConfigFile", () => {
+  let mockElement;
+
+  beforeEach(() => {
+    mockElement = {
+      href: "",
+      download: "",
+      click: vi.fn(),
+    };
+    vi.spyOn(document, "createElement").mockReturnValue(mockElement as any);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => mockElement as any);
+    vi.spyOn(document.body, "removeChild").mockImplementation(() => mockElement as any);
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test-url-2");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  });
+
+  it("downloads file with name from files array", () => {
+    const blob = new Blob(["content"], { type: "text/plain" });
+    const files = [{ fileName: "CLAUDE.md", content: "content", platform: "claude" }];
+    downloadConfigFile(blob, files);
+
+    expect(document.createElement).toHaveBeenCalledWith("a");
+    expect(mockElement.download).toBe("CLAUDE.md");
+    expect(mockElement.click).toHaveBeenCalled();
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-url-2");
+  });
+
+  it("uses fallback filename when files array is empty", () => {
+    const blob = new Blob(["content"], { type: "text/plain" });
+    downloadConfigFile(blob, []);
+
+    expect(mockElement.download).toBe("ai-config.md");
+    expect(mockElement.click).toHaveBeenCalled();
+  });
+
+  it("uses fallback when first file has no fileName", () => {
+    const blob = new Blob(["content"], { type: "text/plain" });
+    downloadConfigFile(blob, [{ content: "test", platform: "cursor" }] as any);
+
+    expect(mockElement.download).toBe("ai-config.md");
+  });
+});

--- a/tests/lib/templates-db-blueprints.test.ts
+++ b/tests/lib/templates-db-blueprints.test.ts
@@ -1,0 +1,296 @@
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Prisma clients
+const mockSystemTemplateFindMany = vi.fn();
+const mockSystemTemplateCount = vi.fn();
+const mockSystemTemplateFindUnique = vi.fn();
+const mockSystemTemplateUpdate = vi.fn();
+const mockUserTemplateFindMany = vi.fn();
+const mockUserTemplateCount = vi.fn();
+const mockUserTemplateFindFirst = vi.fn();
+const mockUserTemplateUpdate = vi.fn();
+const mockTeamMemberFindUnique = vi.fn();
+
+vi.mock("@/lib/db-app", () => ({
+  prismaApp: {
+    systemTemplate: {
+      findMany: (...args: unknown[]) => mockSystemTemplateFindMany(...args),
+      count: (...args: unknown[]) => mockSystemTemplateCount(...args),
+      findUnique: (...args: unknown[]) => mockSystemTemplateFindUnique(...args),
+      update: (...args: unknown[]) => mockSystemTemplateUpdate(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/db-users", () => ({
+  prismaUsers: {
+    userTemplate: {
+      findMany: (...args: unknown[]) => mockUserTemplateFindMany(...args),
+      count: (...args: unknown[]) => mockUserTemplateCount(...args),
+      findFirst: (...args: unknown[]) => mockUserTemplateFindFirst(...args),
+      update: (...args: unknown[]) => mockUserTemplateUpdate(...args),
+    },
+    teamMember: {
+      findUnique: (...args: unknown[]) => mockTeamMemberFindUnique(...args),
+    },
+  },
+}));
+
+// Mock next-auth getServerSession
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+import { getTemplateById } from "@/lib/data/templates";
+
+describe("getTemplateById - database mode bp_/usr_ templates", () => {
+  beforeEach(() => {
+    vi.stubEnv("MOCK", "false");
+    vi.clearAllMocks();
+  });
+
+  it("fetches user template with bp_ prefix - public template, no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "bp-123",
+      name: "User Blueprint",
+      description: "A user blueprint",
+      content: "blueprint content",
+      type: "CURSORRULES",
+      downloads: 30,
+      favorites: 10,
+      tags: ["react"],
+      targetPlatform: "cursor",
+      compatibleWith: ["claude_code"],
+      variables: { APP_NAME: "" },
+      sensitiveFields: {},
+      category: "web",
+      difficulty: "beginner",
+      tier: "SHORT",
+      createdAt: new Date("2024-06-01"),
+      userId: "u-1",
+      user: { name: "Author", id: "u-1" },
+      isPublic: true,
+      visibility: "PUBLIC",
+      teamId: null,
+    });
+
+    const template = await getTemplateById("bp_bp-123");
+    expect(template).not.toBeNull();
+    expect(template!.id).toBe("bp_bp-123");
+    expect(template!.isOfficial).toBe(false);
+    expect(template!.author).toBe("Author");
+    expect(template!.platforms).toContain("cursor");
+  });
+
+  it("fetches user template with usr_ (legacy) prefix", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "legacy-456",
+      name: "Legacy Template",
+      description: "A legacy template",
+      content: "legacy content",
+      type: "CLAUDE_MD",
+      downloads: 5,
+      favorites: 2,
+      tags: [],
+      targetPlatform: null,
+      compatibleWith: null,
+      variables: null,
+      sensitiveFields: null,
+      category: null,
+      difficulty: null,
+      tier: "SHORT",
+      createdAt: new Date("2023-01-01"),
+      userId: "u-2",
+      user: { name: "Legacy Author", id: "u-2" },
+      isPublic: true,
+      visibility: "PUBLIC",
+      teamId: null,
+    });
+
+    const template = await getTemplateById("usr_legacy-456");
+    expect(template).not.toBeNull();
+    expect(template!.id).toBe("bp_legacy-456");
+    expect(template!.author).toBe("Legacy Author");
+    expect(template!.platforms).toContain("claude");
+  });
+
+  it("returns null for non-existent bp_ template", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    mockUserTemplateFindFirst.mockResolvedValue(null);
+
+    const template = await getTemplateById("bp_nonexistent");
+    expect(template).toBeNull();
+  });
+
+  it("allows access when user owns the template", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "owner-1" },
+    });
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "private-tmpl",
+      name: "Private Template",
+      description: "Private",
+      content: "private content",
+      type: "CURSORRULES",
+      downloads: 0,
+      favorites: 0,
+      tags: [],
+      targetPlatform: "cursor",
+      compatibleWith: [],
+      variables: {},
+      sensitiveFields: {},
+      category: null,
+      difficulty: null,
+      tier: "SHORT",
+      createdAt: new Date(),
+      userId: "owner-1",
+      user: { name: "Owner", id: "owner-1" },
+      isPublic: false,
+      visibility: "PRIVATE",
+      teamId: null,
+    });
+
+    const template = await getTemplateById("bp_private-tmpl");
+    expect(template).not.toBeNull();
+    expect(template!.name).toBe("Private Template");
+  });
+
+  it("allows access via team membership", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "team-member-1" },
+    });
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "team-tmpl",
+      name: "Team Template",
+      description: "Team only",
+      content: "team content",
+      type: "WINDSURF_RULES",
+      downloads: 10,
+      favorites: 5,
+      tags: ["team"],
+      targetPlatform: "windsurf",
+      compatibleWith: [],
+      variables: {},
+      sensitiveFields: {},
+      category: "backend",
+      difficulty: "advanced",
+      tier: "LONG",
+      createdAt: new Date(),
+      userId: "other-user",
+      user: { name: "Team Lead", id: "other-user" },
+      isPublic: false,
+      visibility: "TEAM",
+      teamId: "team-abc",
+    });
+    mockTeamMemberFindUnique.mockResolvedValue({ teamId: "team-abc" });
+
+    const template = await getTemplateById("bp_team-tmpl");
+    expect(template).not.toBeNull();
+    expect(template!.name).toBe("Team Template");
+  });
+
+  it("denies access when not team member and not public", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "outsider" },
+    });
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "restricted-tmpl",
+      name: "Restricted",
+      description: "No access",
+      content: "restricted",
+      type: "CURSORRULES",
+      downloads: 0,
+      favorites: 0,
+      tags: [],
+      targetPlatform: null,
+      compatibleWith: null,
+      variables: null,
+      sensitiveFields: null,
+      category: null,
+      difficulty: null,
+      tier: "SHORT",
+      createdAt: new Date(),
+      userId: "someone-else",
+      user: { name: "Someone", id: "someone-else" },
+      isPublic: false,
+      visibility: "TEAM",
+      teamId: "team-xyz",
+    });
+    mockTeamMemberFindUnique.mockResolvedValue(null);
+
+    const template = await getTemplateById("bp_restricted-tmpl");
+    expect(template).toBeNull();
+  });
+
+  it("denies access for private template when not owner", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "not-owner" },
+    });
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "private-other",
+      name: "Not Yours",
+      description: "Private",
+      content: "content",
+      type: "CURSORRULES",
+      downloads: 0,
+      favorites: 0,
+      tags: [],
+      targetPlatform: null,
+      compatibleWith: null,
+      variables: null,
+      sensitiveFields: null,
+      category: null,
+      difficulty: null,
+      tier: "SHORT",
+      createdAt: new Date(),
+      userId: "actual-owner",
+      user: { name: "Actual Owner", id: "actual-owner" },
+      isPublic: false,
+      visibility: "PRIVATE",
+      teamId: null,
+    });
+
+    const template = await getTemplateById("bp_private-other");
+    expect(template).toBeNull();
+  });
+
+  it("handles template with null user (anonymous author)", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    mockUserTemplateFindFirst.mockResolvedValue({
+      id: "anon-tmpl",
+      name: "Anonymous Template",
+      description: "",
+      content: "content",
+      type: "COPILOT_INSTRUCTIONS",
+      downloads: 0,
+      favorites: 0,
+      tags: null,
+      targetPlatform: null,
+      compatibleWith: null,
+      variables: null,
+      sensitiveFields: null,
+      category: null,
+      difficulty: null,
+      tier: "SHORT",
+      createdAt: new Date(),
+      userId: "u-anon",
+      user: null,
+      isPublic: true,
+      visibility: "PUBLIC",
+      teamId: null,
+    });
+
+    const template = await getTemplateById("bp_anon-tmpl");
+    expect(template).not.toBeNull();
+    expect(template!.author).toBe("Anonymous");
+    expect(template!.platforms).toContain("copilot");
+  });
+});

--- a/tests/lib/url-safety-catch.test.ts
+++ b/tests/lib/url-safety-catch.test.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { describe, it, expect } from "vitest";
+import { isSafeUrl } from "@/lib/url-safety";
+
+describe("isSafeUrl - catch block coverage", () => {
+  it("returns false when input causes an exception", () => {
+    // Pass a non-string value that will cause .trim() to throw
+    // The catch block on line 11 should handle this
+    const badInput = { toString() { throw new Error("boom"); } };
+    expect(isSafeUrl(badInput as unknown as string)).toBe(false);
+  });
+
+  it("returns false for null input", () => {
+    expect(isSafeUrl(null as unknown as string)).toBe(false);
+  });
+
+  it("returns false for undefined input", () => {
+    expect(isSafeUrl(undefined as unknown as string)).toBe(false);
+  });
+
+  it("returns false for numeric input", () => {
+    expect(isSafeUrl(123 as unknown as string)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add targeted tests for the 4 lowest-coverage files to push overall line coverage from 90.18% to 91.88%
- **url-safety.ts**: 75% -> 100% (catch block for non-string inputs)
- **templates.ts**: 80.76% -> 99.03% (bp_/usr_ getTemplateById with team access, visibility checks)
- **auth.ts**: 83.23% -> 92.21% (full SSO authorize flow: HMAC verification, nonce consumption, user lookup)
- **file-generator.ts**: 87.66% -> 88.59% (generateConfigFiles, downloadZip, downloadConfigFile)

## Test plan
- [x] All 1075 tests pass locally (48 test files)
- [x] Local coverage: 91.88% lines (target: Codecov reports 90%+)
- [ ] Codecov reports >= 90% after CI run