### PR TITLE
Remove Portainer deploy step

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,20 +75,7 @@ jobs:
           # Cleanup
           cd /tmp && rm -rf watchtower-deploy
 
-      - name: Trigger Portainer deployment
-        run: |
-          curl -sf -X PUT \
-            "${{ secrets.PORTAINER_URL }}/api/stacks/${{ secrets.PORTAINER_STACK_ID }}/git/redeploy?endpointId=${{ secrets.PORTAINER_ENDPOINT_ID }}" \
-            -H "X-API-Key: ${{ secrets.PORTAINER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "PullImage": true,
-              "RepositoryAuthentication": true,
-              "RepositoryUsername": "${{ secrets.GITEA_USERNAME }}",
-              "RepositoryPassword": "${{ secrets.GITEA_TOKEN }}"
-            }'
-
-      - name: Wait for deployment
+      - name: Wait for webhook deployment
         run: sleep 30
 
       - name: Health check


### PR DESCRIPTION
## Summary
- Portainer was removed from all servers (Apr 2026)
- The Gitea push in the previous step already triggers webhook-based deployment
- Replaced with a simple wait step for the webhook to complete