### PR TITLE
ci(dependabot): allow github-actions major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,64 +1,60 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-  open-pull-requests-limit: 10
-  commit-message:
-    prefix: deps
-  labels:
-  - dependencies
-  - automated
-  groups:
-    minor-and-patch:
-      patterns:
-      - '*'
-      update-types:
-      - minor
-      - patch
-    npm_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
-  commit-message:
-    prefix: ci
-  labels:
-  - ci
-  - automated
-  groups:
-    github-actions:
-      patterns:
-      - '*'
-    github_actions_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-  commit-message:
-    prefix: docker
-  labels:
-  - docker
-  - automated
-  groups:
-    docker_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+    labels:
+      - dependencies
+      - automated
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+      npm_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    labels:
+      - ci
+      - automated
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+      github_actions_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: docker
+    labels:
+      - docker
+      - automated
+    groups:
+      docker_security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Removes the `semver-major` ignore from the `github-actions` ecosystem so action major upgrades stop silently drifting. npm/docker majors remain gated.

Auto-merge enabled; merges on green CI.