### PR TITLE
fix(ci): make snap and chocolatey publish jobs non-blocking

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -240,6 +240,10 @@ jobs:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.platforms == 'all' || needs.check.outputs.platforms == 'npm-chocolatey' }}
     runs-on: [self-hosted, Windows, X64]
+    # Secondary distribution channel (npm is primary). The self-hosted Windows
+    # runner may lack the Chocolatey/pwsh toolchain, so never let it fail the
+    # overall release; it self-heals once the runner toolchain is provisioned.
+    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -274,6 +278,11 @@ jobs:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.platforms == 'all' || needs.check.outputs.platforms == 'npm-snap' }}
     runs-on: [self-hosted, Linux, X64]
+    # Secondary distribution channel (npm is primary; the snap just re-wraps the
+    # published npm package). snapd/LXD do not run in the Docker-based self-hosted
+    # runner, so never let this fail the overall release; it self-heals once snap
+    # infra is available on the runner.
+    continue-on-error: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The `Publish CLI` workflow fails on every release. The `publish-snap` job dies at **Setup LXD** with:

```
sudo: snap: command not found
```

Root cause: `publish-snap` (`runs-on: [self-hosted, Linux, X64]`) lands on the `watchtower-lynxprompt` Docker-based self-hosted runner, which has no `snapd`/LXD (snapd needs systemd/privileged container and does not work in a plain Docker runner). The sibling `publish-chocolatey` job (`runs-on: [self-hosted, Windows, X64]`) fails the same way with `pwsh: command not found` / missing `choco`.

The existing `continue-on-error: true` was only on the *final publish step*, so the *infra-setup* steps (Setup LXD, pwsh steps) still turned the jobs — and the whole release — red.

## Fix

Add **job-level** `continue-on-error: true` to `publish-snap` and `publish-chocolatey`.

Why this is the right call (vs. installing snapd-in-Docker or moving to GitHub-hosted runners):

- **Snap & Chocolatey are secondary, derivative channels.** The snap's `snapcraft.yaml` just re-wraps the already-published npm package (`npm install -g lynxprompt@VERSION`). The enforced primary channels — **npm, Homebrew, Docker** — all pass.
- Running snapd inside the Docker self-hosted runner is fragile and unsupported; GitHub-hosted runners aren't in use here (repo runs on self-hosted by preference).
- Job-level `continue-on-error` keeps both jobs **running every release**, so they self-heal automatically once the runner toolchains (snapcraft/LXD, choco/pwsh) are provisioned — no workflow change needed then.

The release summary already renders these channels as ✅/⏭️/⚠️, so a non-blocking failure is surfaced without breaking the release.

## Verification

- [ ] `Publish CLI` workflow runs green (snap/choco jobs no longer fail the run)
- [ ] npm, Homebrew, Docker channels unaffected