### PR TITLE
ci(release): set up Node in release-app job (fixes npm: command not found)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Bump version in package.json if needed
         if: ${{ needs.prepare.outputs.app_bumped == 'true' }}
         run: |


### PR DESCRIPTION
## Problem

The **`release-app`** job in `release.yml` runs `npm version <x> --no-git-tag-version` but has **no Node.js setup step**, so on the self-hosted runner `npm` isn't on PATH:

```
npm version 2.1.1 --no-git-tag-version
... npm: command not found
##[error]Process completed with exit code 127.
```

This has failed `release-app` on **every** app release (observed across the recent dependency-fix merges), so the `app-v*` git tag and GitHub Release are never created. Docker Publish + Deploy to Production are unaffected (they don't depend on this job), so production has stayed current — but the app release/tagging record is stuck at `app-v2.1.0`.

## Fix

Add the same `Setup Node.js` step that the **`release-cli`** job already has (it succeeds), right after checkout and before `npm version`:

```yaml
- name: Setup Node.js
  uses: actions/setup-node@v6
  with:
    node-version: '22'
```

## Notes

- Merging this PR touches `.github/workflows/release.yml`, which is in `release.yml`'s own trigger paths, so it will kick off a Release run. `prepare` will auto-bump the app to the next patch (tag `app-v2.1.0` already exists) and the now-fixed `release-app` should create `app-v2.1.1` + its GitHub Release.
- No app code or dependency changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->