### PR TITLE
security: block fork PRs from running on the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -77,6 +81,10 @@ jobs:
   test:
     name: Test
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -110,6 +118,10 @@ jobs:
   build:
     name: Build
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,11 @@ jobs:
     name: CI Summary
     runs-on: [self-hosted, Linux, X64]
     needs: [lint, test, build]
-    if: always()
+    # always() but still gated to same-repo events (no fork PRs on self-hosted)
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -31,6 +31,10 @@ jobs:
   public-tests:
     name: Public CLI Tests
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -216,6 +220,10 @@ jobs:
   build-test:
     name: Build CLI from Source
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Adds a fork-guard `if:` so `pull_request`-triggered CI jobs run on the self-hosted runner **only for same-repo events**, never for PRs from forks.

## Why
On a public repo, a job that triggers on `pull_request` and runs on a self-hosted runner lets anyone's fork PR execute attacker-controlled code on the runner host. The guard keeps runs self-hosted for trusted events (push, schedule, workflow_dispatch, same-repo branch PRs) while skipping fork PRs. Same pattern already used in `tailscale-rs`.

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

Files: ci.yml, cli-tests.yml
