### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,7 @@ env:
 jobs:
   lint:
     name: Lint & Type Check
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -80,11 +76,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -117,11 +109,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -158,7 +146,7 @@ jobs:
 
   integration-smoke:
     name: Integration Smoke Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'push'
     continue-on-error: true
@@ -199,13 +187,9 @@ jobs:
 
   summary:
     name: CI Summary
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: [lint, test, build]
-    # always() but still gated to same-repo events (no fork PRs on self-hosted)
-    if: >-
-      always() &&
-      (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+    if: always()
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -30,11 +30,7 @@ jobs:
   # Basic tests without authentication
   public-tests:
     name: Public CLI Tests
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -98,9 +94,8 @@ jobs:
   # Uses built-from-source CLI to test current code against dev server
   authenticated-tests:
     name: Authenticated CLI Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: [build-test]  # Ensure build passes first
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       LYNXPROMPT_TOKEN: ${{ secrets.LYNXPROMPT_DEV_TOKEN }}
       LYNXPROMPT_API_URL: https://dev.lynxprompt.com
@@ -219,11 +214,7 @@ jobs:
   # Build from source test
   build-test:
     name: Build CLI from Source
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Development
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     environment:
       name: development
       url: https://dev.lynxprompt.com

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Production
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     environment:
       name: production
       url: https://lynxprompt.com

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-description:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -35,7 +35,7 @@ jobs:
   # Check if this is a CLI release
   # ===========================================
   check:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.version.outputs.version }}
@@ -93,7 +93,7 @@ jobs:
   publish-npm:
     needs: check
     if: ${{ needs.check.outputs.should_publish == 'true' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: cli
@@ -160,7 +160,7 @@ jobs:
   publish-binaries:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.should_publish == 'true' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: cli
@@ -277,7 +277,7 @@ jobs:
   publish-snap:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.platforms == 'all' || needs.check.outputs.platforms == 'npm-snap' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     # Secondary distribution channel (npm is primary; the snap just re-wraps the
     # published npm package). snapd/LXD do not run in the Docker-based self-hosted
     # runner, so never let this fail the overall release; it self-heals once snap
@@ -319,7 +319,7 @@ jobs:
   update-homebrew:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.platforms == 'all' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Homebrew tap
@@ -373,7 +373,7 @@ jobs:
   summary:
     needs: [check, publish-npm, publish-binaries, publish-chocolatey, publish-snap, update-homebrew]
     if: always() && needs.check.outputs.should_publish == 'true'
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Summary

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     permissions:
       contents: write
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   # Detect changes and prepare release
   # ===========================================
   prepare:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     outputs:
       app_changed: ${{ steps.changes.outputs.app }}
       cli_changed: ${{ steps.changes.outputs.cli }}
@@ -190,7 +190,7 @@ jobs:
   release-app:
     needs: prepare
     if: ${{ needs.prepare.outputs.should_release_app == 'true' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -301,7 +301,7 @@ jobs:
   release-cli:
     needs: prepare
     if: ${{ needs.prepare.outputs.should_release_cli == 'true' }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -429,7 +429,7 @@ jobs:
   summary:
     needs: [prepare, release-app, release-cli]
     if: always()
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Summary

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest`.

## Why
GitHub-hosted standard runners are **free and unlimited on public repos**. Moving CI off the home-lab self-hosted runners:
- frees my servers from CI load,
- runs PR code in throwaway isolated VMs (removes the fork-PR attack surface entirely),
- costs $0 on public repos.

The earlier self-hosted fork-guard `if:` is removed (no longer needed on hosted runners). Any macOS/Windows self-hosted jobs (desktop builds) are left unchanged.
