### PR TITLE
ci: migrate CI to github-hosted runners

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -239,7 +239,7 @@ jobs:
   publish-chocolatey:
     needs: [check, publish-npm]
     if: ${{ needs.check.outputs.platforms == 'all' || needs.check.outputs.platforms == 'npm-chocolatey' }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: windows-latest
     # Secondary distribution channel (npm is primary). The self-hosted Windows
     # runner may lack the Chocolatey/pwsh toolchain, so never let it fail the
     # overall release; it self-heals once the runner toolchain is provisioned.


### PR DESCRIPTION
Migrates the `publish-chocolatey` job from the self-hosted Windows runner to GitHub-hosted `windows-latest`.

`windows-latest` ships with Chocolatey and PowerShell preinstalled, which also resolves the toolchain gap called out in the job's own comment (the self-hosted Windows runner "may lack the Chocolatey/pwsh toolchain"). `continue-on-error: true` is retained.

This is the only remaining self-hosted job in `publish-cli.yml` — the Linux jobs already run on `ubuntu-latest`.
