### PR TITLE
fix(deps): update js-yaml to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10995,9 +10995,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update the transitive `js-yaml` dev dependency from 4.3.0 to 4.3.1
- remediate GHSA-5p4m-2wfm-xmqj
- keep the change isolated to `package-lock.json`

## Dependency path

`eslint@9.39.5` → `@eslint/eslintrc@3.3.6` → `js-yaml@^4.3.0`

## Verification

- `npm audit --audit-level=low` (0 vulnerabilities)
- `npm audit --omit=dev --audit-level=low` (0 vulnerabilities)
- `npm run db:generate`
- `npm run typecheck`
- `npm test -- --run --coverage` (49 files, 1,078 tests passed)
- `npm run build`
- `git diff --check`

`npm run lint` remains blocked by the repository-documented `eslint-config-next@16` FlatCompat circular-structure bug; the lint step is currently disabled in CI for the same reason.