### PR TITLE
deps: bump js-yaml to 4.3.2 to close a new HIGH alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10999,9 +10999,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
A new HIGH alert ([#177](https://github.com/GeiserX/LynxPrompt/security/dependabot/177), [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh), CVSS 7.5) landed on `main` minutes after #140 merged: `maxTotalMergeKeys` does not limit CPU use for empty merge sources. It is the follow-up to the js-yaml advisory fixed last month, which took us to 4.3.1. The fix is 4.3.2.

## Change

Lockfile only, 3 lines. js-yaml is a transitive dev dependency and its only dependent declares `js-yaml: ^4.3.0`, so 4.3.2 satisfies it with no `overrides` entry. There is a single hoisted copy in the tree, now at 4.3.2.

## Verification

- `vitest run`: 1078 passed (49 files)
- `tsc --noEmit`: clean
- Every js-yaml copy in the lockfile is at 4.3.2

`npm run lint` still fails the same way it does on `main` (`TypeError: Converting circular structure to JSON` inside ESLint's own config loader). Pre-existing and unrelated, same as on #140.